### PR TITLE
chore: move production code debug log to info level

### DIFF
--- a/apps/omg/lib/omg/root_chain_coordinator.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator.ex
@@ -106,7 +106,7 @@ defmodule OMG.RootChainCoordinator do
   end
 
   def handle_call({:check_in, synced_height, service_name}, {pid, _ref}, state) do
-    _ = Logger.debug("#{inspect(service_name)} checks in on height #{inspect(synced_height)}")
+    _ = Logger.info("#{inspect(service_name)} checks in on height #{inspect(synced_height)}")
 
     {:ok, state} = Core.check_in(state, pid, synced_height, service_name)
     {:reply, :ok, state}

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -259,10 +259,10 @@ defmodule OMG.State do
     - pushes the new block to subscribers of `"blocks"` internal event bus topic
   """
   def handle_cast(:form_block, state) do
-    _ = Logger.debug("Forming new block...")
+    _ = Logger.info("Forming new block...")
     state = Core.claim_fees(state)
     {:ok, {%Block{number: blknum} = block, db_updates}, new_state} = Core.form_block(state)
-    _ = Logger.debug("Formed new block ##{blknum}")
+    _ = Logger.info("Formed new block ##{blknum}")
 
     # persistence is required to be here, since propagating the block onwards requires restartability including the
     # new block

--- a/apps/omg_child_chain/lib/child_chain.ex
+++ b/apps/omg_child_chain/lib/child_chain.ex
@@ -67,7 +67,7 @@ defmodule OMG.ChildChain do
   defp is_supported(%Transaction.Recovered{}), do: :ok
 
   defp result_with_logging(result) do
-    _ = Logger.debug(" resulted with #{inspect(result)}")
+    _ = Logger.info(" resulted with #{inspect(result)}")
     result
   end
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -165,7 +165,7 @@ defmodule OMG.ChildChain.BlockQueue do
     mined_blknum = RootChain.get_mined_child_block()
     {_, is_empty_block} = OMG.State.get_status()
 
-    _ = Logger.debug("Ethereum at \#'#{inspect(ethereum_height)}', mined child at \#'#{inspect(mined_blknum)}'")
+    _ = Logger.info("Ethereum at \#'#{inspect(ethereum_height)}', mined child at \#'#{inspect(mined_blknum)}'")
 
     state1 =
       case Core.set_ethereum_status(state, ethereum_height, mined_blknum, is_empty_block) do

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -214,7 +214,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   """
   @spec get_blocks_to_submit(Core.t()) :: [BlockQueue.encoded_signed_tx()]
   def get_blocks_to_submit(%{blocks: blocks, formed_child_block_num: formed} = state) do
-    _ = Logger.debug("preparing blocks #{inspect(next_blknum_to_mine(state))}..#{inspect(formed)} for submission")
+    _ = Logger.info("preparing blocks #{inspect(next_blknum_to_mine(state))}..#{inspect(formed)} for submission")
 
     blocks
     |> Enum.filter(to_mined_block_filter(state))
@@ -401,7 +401,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
       state
     else
       new_gas_price = calculate_gas_price(state)
-      _ = Logger.debug("using new gas price '#{inspect(new_gas_price)}'")
+      _ = Logger.info("using new gas price '#{inspect(new_gas_price)}'")
 
       new_state =
         state
@@ -514,7 +514,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
           is_empty_block: is_empty_block
         }
 
-        Logger.debug("Skipping forming block because: #{inspect(log_data)}")
+        Logger.info("Skipping forming block because: #{inspect(log_data)}")
       end
 
     should_form_block
@@ -612,12 +612,12 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   end
 
   defp log_known_tx(submission) do
-    _ = Logger.debug("Submission #{inspect(submission)} is known transaction - ignored")
+    _ = Logger.info("Submission #{inspect(submission)} is known transaction - ignored")
     :ok
   end
 
   defp log_low_replacement_price(submission) do
-    _ = Logger.debug("Submission #{inspect(submission)} is known, but with higher price - ignored")
+    _ = Logger.info("Submission #{inspect(submission)} is known, but with higher price - ignored")
     :ok
   end
 

--- a/apps/omg_child_chain/lib/omg_child_chain/ethereum_event_aggregator.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/ethereum_event_aggregator.ex
@@ -14,7 +14,7 @@
 defmodule OMG.ChildChain.EthereumEventAggregator do
   @moduledoc """
   This process combines all plasma contract events we're interested in and does eth_getLogs + enriches them if needed
-  for all Ethereum Event Listener processes. 
+  for all Ethereum Event Listener processes.
   """
   use GenServer
   require Logger
@@ -258,7 +258,7 @@ defmodule OMG.ChildChain.EthereumEventAggregator do
         missing_to_block = List.last(missing_blocks)
 
         _ =
-          Logger.debug(
+          Logger.info(
             "Missing block information (#{missing_from_block}, #{missing_to_block}) in event fetcher. Additional RPC call to gather logs."
           )
 

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_fee_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_fee_parser.ex
@@ -99,7 +99,7 @@ defmodule OMG.ChildChain.Fees.JSONFeeParser do
   end
 
   defp handle_parser_output({[], fee_specs}) do
-    _ = Logger.debug("Parsing fee specification file completes successfully.")
+    _ = Logger.info("Parsing fee specification file completes successfully.")
     {:ok, fee_specs}
   end
 

--- a/apps/omg_eth/lib/omg_eth/ethereum_height.ex
+++ b/apps/omg_eth/lib/omg_eth/ethereum_height.ex
@@ -46,7 +46,7 @@ defmodule OMG.Eth.EthereumHeight do
   end
 
   def handle_info({:internal_event_bus, :ethereum_new_height, new_height}, _state) do
-    _ = Logger.debug("Got an internal :ethereum_new_height event with height: #{new_height}.")
+    _ = Logger.info("Got an internal :ethereum_new_height event with height: #{new_height}.")
     {:noreply, new_height}
   end
 

--- a/apps/omg_utils/lib/omg_utils/http_rpc/adapter.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/adapter.ex
@@ -28,7 +28,7 @@ defmodule OMG.Utils.HttpRPC.Adapter do
 
     with {:ok, body} <- Jason.encode(body),
          {:ok, %HTTPoison.Response{} = response} <- HTTPoison.post(addr, body, headers) do
-      _ = Logger.debug("rpc post #{inspect(addr)} completed successfully")
+      _ = Logger.info("rpc post #{inspect(addr)} completed successfully")
       response
     else
       err ->

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -175,7 +175,7 @@ defmodule OMG.Watcher.BlockGetter do
 
     {state, synced_height, db_updates} = Core.apply_block(state, block_application)
 
-    _ = Logger.debug("Synced height update: #{inspect(db_updates)}")
+    _ = Logger.info("Synced height update: #{inspect(db_updates)}")
 
     :ok = OMG.DB.multi_update(db_updates ++ db_updates_from_state)
     :ok = check_in_to_coordinator(synced_height)
@@ -292,7 +292,7 @@ defmodule OMG.Watcher.BlockGetter do
       {blocks_to_apply, synced_height, db_updates, state} =
         Core.get_blocks_to_apply(state, submissions, next_synced_height)
 
-      _ = Logger.debug("Synced height is #{inspect(synced_height)}, got #{length(blocks_to_apply)} blocks to apply")
+      _ = Logger.info("Synced height is #{inspect(synced_height)}, got #{length(blocks_to_apply)} blocks to apply")
 
       Enum.each(blocks_to_apply, &GenServer.cast(__MODULE__, {:apply_block, &1}))
 

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/core.ex
@@ -197,7 +197,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
         eth_height: eth_height,
         eth_height_done: eth_height_done
       }) do
-    _ = Logger.debug("\##{inspect(blknum)}, from: #{inspect(eth_height)}, eth height done: #{inspect(eth_height_done)}")
+    _ = Logger.info("\##{inspect(blknum)}, from: #{inspect(eth_height)}, eth height done: #{inspect(eth_height_done)}")
 
     if eth_height_done do
       # final - we need to mark this eth height as processed
@@ -330,7 +330,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
         _time
       ) do
     _ =
-      Logger.debug(fn ->
+      Logger.info(fn ->
         short_hash = returned_hash |> OMG.Eth.Encoding.to_hex() |> Binary.drop(-48)
 
         "Validating block \##{inspect(requested_number)} #{inspect(short_hash)}... " <>

--- a/apps/omg_watcher/lib/omg_watcher/ethereum_event_aggregator.ex
+++ b/apps/omg_watcher/lib/omg_watcher/ethereum_event_aggregator.ex
@@ -14,7 +14,7 @@
 defmodule OMG.Watcher.EthereumEventAggregator do
   @moduledoc """
   This process combines all plasma contract events we're interested in and does eth_getLogs + enriches them if needed
-  for all Ethereum Event Listener processes. 
+  for all Ethereum Event Listener processes.
   """
   use GenServer
   require Logger
@@ -336,7 +336,7 @@ defmodule OMG.Watcher.EthereumEventAggregator do
         missing_to_block = List.last(missing_blocks)
 
         _ =
-          Logger.debug(
+          Logger.info(
             "Missing block information (#{missing_from_block}, #{missing_to_block}) in event fetcher. Retrieving from RPC."
           )
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -638,7 +638,7 @@ defmodule OMG.Watcher.ExitProcessor do
     {:ok, eth_height_now} = EthereumHeight.get()
     {blknum_now, _} = State.get_status()
 
-    _ = Logger.debug("eth_height_now: #{inspect(eth_height_now)}, blknum_now: #{inspect(blknum_now)}")
+    _ = Logger.info("eth_height_now: #{inspect(eth_height_now)}, blknum_now: #{inspect(blknum_now)}")
     %{request | eth_height_now: eth_height_now, blknum_now: blknum_now}
   end
 
@@ -650,7 +650,7 @@ defmodule OMG.Watcher.ExitProcessor do
 
   defp do_utxo_exists?(positions) do
     result = positions |> Enum.map(&State.utxo_exists?/1)
-    _ = Logger.debug("utxos_to_check: #{inspect(positions)}, utxo_exists_result: #{inspect(result)}")
+    _ = Logger.info("utxos_to_check: #{inspect(positions)}, utxo_exists_result: #{inspect(result)}")
     result
   end
 
@@ -662,7 +662,7 @@ defmodule OMG.Watcher.ExitProcessor do
 
   defp do_get_spending_blocks(spent_positions_to_get) do
     blknums = spent_positions_to_get |> Enum.map(&do_get_spent_blknum/1)
-    _ = Logger.debug("spends_to_get: #{inspect(spent_positions_to_get)}, spent_blknum_result: #{inspect(blknums)}")
+    _ = Logger.info("spends_to_get: #{inspect(spent_positions_to_get)}, spent_blknum_result: #{inspect(blknums)}")
 
     blknums
     |> Core.handle_spent_blknum_result(spent_positions_to_get)
@@ -671,9 +671,9 @@ defmodule OMG.Watcher.ExitProcessor do
 
   defp do_get_blocks(blknums) do
     {:ok, hashes} = OMG.DB.block_hashes(blknums)
-    _ = Logger.debug("blknums: #{inspect(blknums)}, hashes: #{inspect(hashes)}")
+    _ = Logger.info("blknums: #{inspect(blknums)}, hashes: #{inspect(hashes)}")
     {:ok, blocks} = OMG.DB.blocks(hashes)
-    _ = Logger.debug("blocks_result: #{inspect(blocks)}")
+    _ = Logger.info("blocks_result: #{inspect(blocks)}")
 
     Enum.map(blocks, &Block.from_db_value/1)
   end

--- a/apps/omg_watcher_info/lib/omg_watcher_info/http_rpc/adapter.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/http_rpc/adapter.ex
@@ -28,7 +28,7 @@ defmodule OMG.WatcherInfo.HttpRPC.Adapter do
 
     with {:ok, body} <- Jason.encode(body),
          {:ok, %HTTPoison.Response{} = response} <- HTTPoison.post(addr, body, headers) do
-      _ = Logger.debug("rpc post #{inspect(addr)} completed successfully")
+      _ = Logger.info("rpc post #{inspect(addr)} completed successfully")
       response
     else
       err ->


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

I have found it sometimes hard to collect enough info to understand a root cause of a Sentry issue.
As a result, I would like to propose move all debug logs to info level to ensure it would show up in data dog.

## Changes

find all non test code with `Logger.debug` and move them to `Logger.info`.

## Testing

N/A
