### PR TITLE
fix: skip byzantine event tests

### DIFF
--- a/apps/omg/test/test_helper.exs
+++ b/apps/omg/test/test_helper.exs
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ExUnitFixtures.start()
-ExUnit.configure(exclude: [integration: true, property: true, wrappers: true])
+ExUnit.configure(exclude: [skip: true, integration: true, property: true, wrappers: true])
 ExUnitFixtures.load_fixture_files(Path.join([Mix.Project.build_path(), "../../", "apps/*/test/**/fixtures.exs"]))
 ExUnit.start()
 

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -24,7 +24,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
 
   use OMG.Performance
 
-  @moduletag :integration
+  @moduletag :skip
   @moduletag timeout: 180_000
 
   @number_of_transactions_to_send 10

--- a/apps/omg_performance/test/test_helper.exs
+++ b/apps/omg_performance/test/test_helper.exs
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ExUnit.configure(exclude: [integration: true, property: true, wrappers: true])
+ExUnit.configure(exclude: [skip: true, integration: true, property: true, wrappers: true])
 ExUnitFixtures.start()
 ExUnit.start()
 {:ok, _} = Application.ensure_all_started(:briefly)


### PR DESCRIPTION
## Overview

Some of the Byzantine perf tests are randomly failing. This PR introduces a `skip` tag to skip those tests for now. They should be moved to a different place in the future.

## Changes

- New `skip` tag
- Skip `skip` tests in Perf sub app

