### PR TITLE
Inomurko/reorg block getter

### DIFF
--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -58,7 +58,7 @@ defmodule OMG.Eth.RootChain do
   def get_block_submitted_events(from_height, to_height) do
     contract = Configuration.contracts().plasma_framework
     signature = "BlockSubmitted(uint256)"
-    {:ok, logs} = Rpc.get_ethereum_events(from_height, to_heigh, signature, contract)
+    {:ok, logs} = Rpc.get_ethereum_events(from_height, to_height, signature, contract)
 
     Enum.map(logs, &Abi.decode_log(&1))
   end

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -60,7 +60,7 @@ defmodule OMG.Eth.RootChain do
     signature = "BlockSubmitted(uint256)"
     {:ok, logs} = Rpc.get_ethereum_events(from_height, to_height, signature, contract)
 
-    Enum.map(logs, &Abi.decode_log(&1))
+    {:ok, Enum.map(logs, &Abi.decode_log(&1))}
   end
 
   ##

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -52,6 +52,17 @@ defmodule OMG.Eth.RootChain do
     {block_hash, block_timestamp}
   end
 
+  @doc """
+  Returns lists of block submissions from Ethereum logs	
+  """
+  def get_block_submitted_events(from_height, to_height) do
+    contract = Configuration.contracts().plasma_framework
+    signature = "BlockSubmitted(uint256)"
+    {:ok, logs} = Rpc.get_ethereum_events(from_height, to_heigh, signature, contract)
+
+    Enum.map(logs, &Abi.decode_log(&1))
+  end
+
   ##
   ## these two cannot be parsed with ABI decoder!
   ##

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -56,7 +56,7 @@ defmodule OMG.Eth.RootChain do
   Returns lists of block submissions from Ethereum logs	
   """
   def get_block_submitted_events(from_height, to_height) do
-    contract = Configuration.contracts().plasma_framework
+    contract = from_hex(Configuration.contracts().plasma_framework)
     signature = "BlockSubmitted(uint256)"
     {:ok, logs} = Rpc.get_ethereum_events(from_height, to_height, signature, contract)
 

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -44,15 +44,14 @@ defmodule OMG.Watcher.BlockGetter do
   use GenServer
   use OMG.Utils.LoggerExt
   use Spandex.Decorators
-  alias OMG.Eth.RootChain
 
+  alias OMG.Eth.RootChain
   alias OMG.RootChainCoordinator
   alias OMG.RootChainCoordinator.SyncGuide
   alias OMG.State
   alias OMG.Watcher.BlockGetter.BlockApplication
   alias OMG.Watcher.BlockGetter.Core
   alias OMG.Watcher.BlockGetter.Status
-  alias OMG.Watcher.EthereumEventAggregator
   alias OMG.Watcher.ExitProcessor
   alias OMG.Watcher.HttpRPC.Client
 
@@ -317,8 +316,9 @@ defmodule OMG.Watcher.BlockGetter do
   end
 
   @decorate trace(tracer: OMG.Watcher.Tracer, type: :backend, service: :block_getter)
-  defp get_block_submitted_events(block_from, block_to),
-    do: EthereumEventAggregator.block_submitted(block_from, block_to)
+  defp get_block_submitted_events(block_from, block_to) do
+    RootChain.block_submitted(block_from, block_to)
+  end
 
   defp run_block_download_task(state) do
     next_child = RootChain.next_child_block()

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -317,7 +317,7 @@ defmodule OMG.Watcher.BlockGetter do
 
   @decorate trace(tracer: OMG.Watcher.Tracer, type: :backend, service: :block_getter)
   defp get_block_submitted_events(block_from, block_to) do
-    RootChain.block_submitted(block_from, block_to)
+    RootChain.get_block_submitted_events(block_from, block_to)
   end
 
   defp run_block_download_task(state) do

--- a/apps/omg_watcher/lib/omg_watcher/ethereum_event_aggregator.ex
+++ b/apps/omg_watcher/lib/omg_watcher/ethereum_event_aggregator.ex
@@ -115,81 +115,75 @@ defmodule OMG.Watcher.EthereumEventAggregator do
        event_signatures: events_signatures,
        events: events,
        contracts: contracts,
-       rpc: rpc,
-       caller: nil
+       rpc: rpc
      }}
   end
 
   @decorate trace(tracer: OMG.Watcher.Tracer, type: :backend, service: __MODULE__, name: "handle_call/3")
   def handle_call({:in_flight_exit_withdrawn, from_block, to_block}, _, state) do
     names = [:in_flight_exit_input_withdrawn, :in_flight_exit_output_withdrawn]
-    state0 = Map.put(state, :caller, name)
 
     logs =
       Enum.reduce(names, [], fn name, acc ->
         signature =
-          state0.events
+          state.events
           |> Enum.find(fn event -> Keyword.fetch!(event, :name) == name end)
           |> Keyword.fetch!(:signature)
 
-        logs = retrieve_log(signature, from_block, to_block, state0)
+        logs = retrieve_log(signature, from_block, to_block, state)
         logs ++ acc
       end)
 
-    {:reply, {:ok, logs}, state0, {:continue, from_block}}
+    {:reply, {:ok, logs}, state, {:continue, from_block}}
   end
 
   @decorate trace(tracer: OMG.Watcher.Tracer, type: :backend, service: __MODULE__, name: "handle_call/3")
   def handle_call({:in_flight_exit_blocked, from_block, to_block}, _, state) do
     names = [:in_flight_exit_input_blocked, :in_flight_exit_output_blocked]
-    state0 = Map.put(state, :caller, name)
 
     logs =
       names
       |> Enum.reduce([], fn name, acc ->
         signature =
-          state0.events
+          state.events
           |> Enum.find(fn event -> Keyword.fetch!(event, :name) == name end)
           |> Keyword.fetch!(:signature)
 
-        logs = retrieve_log(signature, from_block, to_block, state0)
+        logs = retrieve_log(signature, from_block, to_block, state)
         logs ++ acc
       end)
 
-    {:reply, {:ok, logs}, state0, {:continue, from_block}}
+    {:reply, {:ok, logs}, state, {:continue, from_block}}
   end
 
   @decorate trace(tracer: OMG.Watcher.Tracer, type: :backend, service: __MODULE__, name: "handle_call/3")
   def handle_call({:in_flight_exit_piggybacked, from_block, to_block}, _, state) do
     names = [:in_flight_exit_output_piggybacked, :in_flight_exit_input_piggybacked]
-    state0 = Map.put(state, :caller, name)
 
     logs =
       names
       |> Enum.reduce([], fn name, acc ->
         signature =
-          state0.events
+          state.events
           |> Enum.find(fn event -> Keyword.fetch!(event, :name) == name end)
           |> Keyword.fetch!(:signature)
 
-        logs = retrieve_log(signature, from_block, to_block, state0)
+        logs = retrieve_log(signature, from_block, to_block, state)
         logs ++ acc
       end)
 
-    {:reply, {:ok, logs}, state0, {:continue, from_block}}
+    {:reply, {:ok, logs}, state, {:continue, from_block}}
   end
 
   @decorate trace(tracer: OMG.Watcher.Tracer, type: :backend, service: __MODULE__, name: "handle_call/3")
   def handle_call({name, from_block, to_block}, _, state) do
-    state0 = Map.put(state, :caller, name)
-
     signature =
-      state0.events
+      state.events
       |> Enum.find(fn event -> Keyword.fetch!(event, :name) == name end)
       |> Keyword.fetch!(:signature)
 
-    logs = retrieve_log(signature, from_block, to_block, state0)
-    {:reply, {:ok, logs}, state0, {:continue, from_block}}
+    logs = retrieve_log(signature, from_block, to_block, state)
+    {:reply, {:ok, logs}, state, {:continue, from_block}}
   end
 
   defp forward_call(server, event, from_block, to_block, timeout) when from_block <= to_block do
@@ -239,11 +233,6 @@ defmodule OMG.Watcher.EthereumEventAggregator do
           decoded_log
       end
     end)
-  end
-
-  # blockgetter runs in front of everyone, we don't want his events stored without reorg protection
-  defp store_logs(_, _, _, %{caller: :block_submitted}) do
-    :ok
   end
 
   defp store_logs(decoded_logs, from_block, to_block, state) do

--- a/apps/omg_watcher/lib/omg_watcher/ethereum_event_aggregator.ex
+++ b/apps/omg_watcher/lib/omg_watcher/ethereum_event_aggregator.ex
@@ -78,11 +78,6 @@ defmodule OMG.Watcher.EthereumEventAggregator do
     forward_call(server, :in_flight_exit_withdrawn, from_block, to_block, @timeout)
   end
 
-  @spec block_submitted(GenServer.server(), pos_integer(), pos_integer()) :: result()
-  def block_submitted(server \\ __MODULE__, from_block, to_block) do
-    forward_call(server, :block_submitted, from_block, to_block, @timeout)
-  end
-
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
   end

--- a/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
@@ -109,9 +109,7 @@ defmodule OMG.Watcher.SyncSupervisor do
          [name: :in_flight_exit_input_blocked, enrich: false],
          [name: :in_flight_exit_output_blocked, enrich: false],
          [name: :in_flight_exit_input_withdrawn, enrich: false],
-         [name: :in_flight_exit_output_withdrawn, enrich: false],
-         # blockgetter
-         [name: :block_submitted, enrich: false]
+         [name: :in_flight_exit_output_withdrawn, enrich: false]
        ]},
       EthereumEventListener.prepare_child(
         metrics_collection_interval: metrics_collection_interval,


### PR DESCRIPTION

## Overview

I've observed two things:
```
:sys.get_state OMG.Watcher.BlockGetter
%OMG.Watcher.BlockGetter.Core{
  chain_status: :ok,
  config: %OMG.Watcher.BlockGetter.Core.Config{
    block_getter_loops_interval_ms: 500,
    block_getter_reorg_margin: 200,
    block_interval: 1000,
    child_chain_url: "http://childchain:80",
    maximum_block_withholding_time_ms: 54000000,
    maximum_number_of_pending_blocks: 4,
    maximum_number_of_unapplied_blocks: 50
  },
  events: [],
  last_applied_block: 241000,
  num_of_highest_block_being_downloaded: 241000,
  number_of_blocks_being_downloaded: 0,
  potential_block_withholdings: %{},
  synced_height: 10178703,
  unapplied_blocks: %{}
}
iex(watcher_info@127.0.0.1)14> :sys.get_state :depositor
{%OMG.EthereumEventListener.Core{
   cached: %{data: [], events_upper_bound: 10178693, request_max_size: 1000},
   ethereum_events_check_interval_ms: 8000,
   service_name: :depositor,
   synced_height: 10178693,
   synced_height_update_key: :last_depositor_eth_height
 },
 %{
   get_ethereum_events_callback: &OMG.Watcher.EthereumEventAggregator.deposit_created/2,
   process_events_callback: &OMG.State.deposit/1
 }}
```
So two services are syncing, but blockgetter is faster then depositor.
BlockGetter synced_height: 10178703
Depositor synced_height: 10178693

The consolidation PR https://github.com/omgnetwork/elixir-omg/pull/1376 introduced a behaviour where all services go through the same funnel to fetch ethereum logs while relying on :depositor reorg protection.

It was observed that :depositor and :block_getter do not have constraints with one another:
```
depositor: [finality_margin: deposit_finality_margin],
       block_getter: [
         waits_for: [depositor: :no_margin],
         finality_margin: 0
       ]
```

A following event could cause watcher to have issues:
- block was formed on height 10
- blockgetter gets that block + all other events (defined in  `OMG.Watcher.SyncSupervisor`, `EthereumEventAggregator`, `events`)
- deposits or exits or whatever event happens after the block formation
- a reorg happens in the depositor reorg protection margin (10 blocks)

This would cause the ETS table of event aggregator to store same ethereum log on two different heights.

## Changes

- BlockGetter has it's own reorg protection so we're letting him sync separately from ethereum event aggregator

## Testing

Same tests apply.