### PR TITLE
prevent race condition for status cache

### DIFF
--- a/apps/omg/lib/omg/root_chain_coordinator.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator.ex
@@ -72,10 +72,6 @@ defmodule OMG.RootChainCoordinator do
   end
 
   def init({args, configs_services}) do
-    {:ok, {args, configs_services}, {:continue, :setup}}
-  end
-
-  def handle_continue(:setup, {args, configs_services}) do
     _ = Logger.info("Starting #{__MODULE__} service. #{inspect({args, configs_services})}")
     metrics_collection_interval = Keyword.fetch!(args, :metrics_collection_interval)
     coordinator_eth_height_check_interval_ms = Keyword.fetch!(args, :coordinator_eth_height_check_interval_ms)
@@ -91,7 +87,7 @@ defmodule OMG.RootChainCoordinator do
 
     _ = Logger.info("Started #{inspect(__MODULE__)}")
 
-    {:noreply, state}
+    {:ok, state}
   end
 
   def handle_info(:send_metrics, state) do

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -67,17 +67,10 @@ defmodule OMG.Watcher.BlockGetter do
   end
 
   @doc """
-  Initializes the GenServer state, most work done in `handle_continue/2`.
-  """
-  def init(args) do
-    {:ok, args, {:continue, :setup}}
-  end
-
-  @doc """
   Reads the status of block getting and application from `OMG.DB`, reads the current state of the contract and root
   chain and starts the pollers that will take care of getting blocks.
   """
-  def handle_continue(:setup, args) do
+  def init(args) do
     child_block_interval = Keyword.fetch!(args, :child_block_interval)
     # how many eth blocks backward can change during an reorg
     block_getter_reorg_margin = Keyword.fetch!(args, :block_getter_reorg_margin)
@@ -131,7 +124,7 @@ defmodule OMG.Watcher.BlockGetter do
         }"
       )
 
-    {:noreply, state}
+    {:ok, state}
   end
 
   # :apply_block pipeline of steps

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -304,11 +304,7 @@ defmodule OMG.Watcher.ExitProcessor do
   - updates the `ExitProcessor`'s state
   - returns `db_updates`
   """
-  def handle_call(
-        {:new_exits, exits},
-        _from,
-        state
-      ) do
+  def handle_call({:new_exits, exits}, _from, state) do
     _ = if not Enum.empty?(exits), do: Logger.info("Recognized exits: #{inspect(exits)}")
 
     {:ok, exit_contract_statuses} = Eth.RootChain.get_standard_exit_structs(get_in(exits, [Access.all(), :exit_id]))

--- a/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
@@ -70,6 +70,13 @@ defmodule OMG.Watcher.SyncSupervisor do
     contracts = OMG.Eth.Configuration.contracts()
 
     [
+      {OMG.RootChainCoordinator,
+       CoordinatorSetup.coordinator_setup(
+         metrics_collection_interval,
+         coordinator_eth_height_check_interval_ms,
+         finality_margin,
+         deposit_finality_margin
+       )},
       {ExitProcessor,
        [
          exit_processor_sla_margin: exit_processor_sla_margin,
@@ -86,13 +93,6 @@ defmodule OMG.Watcher.SyncSupervisor do
         restart: :permanent,
         type: :supervisor
       },
-      {OMG.RootChainCoordinator,
-       CoordinatorSetup.coordinator_setup(
-         metrics_collection_interval,
-         coordinator_eth_height_check_interval_ms,
-         finality_margin,
-         deposit_finality_margin
-       )},
       {EthereumEventAggregator,
        contracts: contracts,
        ets_bucket: events_bucket(),


### PR DESCRIPTION
https://github.com/omgnetwork/elixir-omg/issues/1557

## Overview

Fixing the order of booted dependencies and made some bootup synchronus instead of async.

## Changes

- status.get endpoint has dependencies to underlying services like OMG.Watcher.BlockGetter, OMG.Watcher.ExitProcessor, OMG.State. These dependencies need to be available with the first status.get call (even if it's cache!). 

## Testing

`mix test`
