### PR TITLE
global block get interval

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
@@ -32,11 +32,11 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
     block_getter_reorg_margin = Configuration.block_getter_reorg_margin()
     maximum_block_withholding_time_ms = Configuration.maximum_block_withholding_time_ms()
     maximum_number_of_unapplied_blocks = Configuration.maximum_number_of_unapplied_blocks()
-    block_getter_loops_interval_ms = Configuration.block_getter_loops_interval_ms()
     metrics_collection_interval = Configuration.metrics_collection_interval()
     child_chain_url = Configuration.child_chain_url()
     child_block_interval = OMG.Eth.Configuration.child_block_interval()
     contracts = OMG.Eth.Configuration.contracts()
+    block_getter_loops_interval_ms = OMG.Configuration.ethereum_events_check_interval_ms()
 
     fee_claimer_address = Base.decode16!("DEAD000000000000000000000000000000000000")
 

--- a/apps/omg_watcher/lib/omg_watcher/configuration.ex
+++ b/apps/omg_watcher/lib/omg_watcher/configuration.ex
@@ -41,10 +41,6 @@ defmodule OMG.Watcher.Configuration do
     Application.fetch_env!(@app, :maximum_number_of_unapplied_blocks)
   end
 
-  def block_getter_loops_interval_ms() do
-    Application.fetch_env!(@app, :block_getter_loops_interval_ms)
-  end
-
   def child_chain_url() do
     Application.get_env(@app, :child_chain_url)
   end

--- a/config/config.exs
+++ b/config/config.exs
@@ -159,7 +159,6 @@ config :omg_watcher,
   # this means we don't want the `sla_margin` above be larger than the `min_exit_period`
   exit_processor_sla_margin_forced: false,
   maximum_block_withholding_time_ms: 15 * 60 * 60 * 1000,
-  block_getter_loops_interval_ms: 500,
   maximum_number_of_unapplied_blocks: 50,
   exit_finality_margin: 12,
   block_getter_reorg_margin: 200,

--- a/config/test.exs
+++ b/config/test.exs
@@ -133,7 +133,6 @@ config :os_mon,
 config :omg_watcher, child_chain_url: "http://localhost:9657"
 
 config :omg_watcher,
-  block_getter_loops_interval_ms: 50,
   # NOTE `exit_processor_sla_margin` can't be made shorter. At 8 it sometimes
   # causes unchallenged exits events because `geth --dev` is too fast
   exit_processor_sla_margin: 10,

--- a/docs/details.md
+++ b/docs/details.md
@@ -230,8 +230,6 @@ Defaults to `false`, override using the `EXIT_PROCESSOR_SLA_MARGIN_FORCED` syste
 
 * **`maximum_block_withholding_time_ms`** - for how long the Watcher will tolerate failures to get a submitted child chain block, before reporting a block withholding attack and stopping
 
-* **`block_getter_loops_interval_ms`** - polling interval for checking new child chain blocks submissions being mined on the root chain
-
 * **`maximum_number_of_unapplied_blocks`** - the maximum number of downloaded and statelessly validated child chain blocks to hold in queue for applying
 
 * **`exit_finality_margin`** - the margin waited before an exit-related event is considered final enough to pull and process


### PR DESCRIPTION


## Overview

Reducing the aggressiveness of blockgetter.
 
## Changes

- Timers per global block issuance rate. 8seconds. 

## Testing


