### PR TITLE
cabbage test for payment v2

### DIFF
--- a/apps/omg/lib/omg/state/transaction/payment/builder.ex
+++ b/apps/omg/lib/omg/state/transaction/payment/builder.ex
@@ -1,0 +1,88 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Transaction.Payment.Builder do
+  @moduledoc """
+  Module to build payment tx of different tx types. (eg. v1 and v2)
+  """
+
+  alias OMG.Crypto
+  alias OMG.State.Transaction
+  alias OMG.State.Transaction.Payment
+  alias OMG.Output
+  alias OMG.Utxo
+
+  require Transaction
+  require Utxo
+
+  @max_inputs 4
+  @max_outputs 4
+  @zero_metadata <<0::256>>
+
+  @payment_tx_type OMG.WireFormatTypes.tx_type_for(:tx_payment_v1)
+  @payment_output_type OMG.WireFormatTypes.output_type_for(:output_payment_v1)
+
+  @payment_v2_tx_type OMG.WireFormatTypes.tx_type_for(:tx_payment_v2)
+  @payment_v2_output_type OMG.WireFormatTypes.output_type_for(:output_payment_v2)
+
+  @doc """
+  Creates a new raw transaction structure from a list of inputs and a list of outputs, given in a succinct tuple form.
+
+  assumptions:
+  ```
+    length(inputs) <= @max_inputs
+    length(outputs) <= @max_outputs
+  ```
+  """
+  @spec new_payment(
+          list({pos_integer, pos_integer, 0..unquote(@max_outputs - 1)}),
+          list({Crypto.address_t(), Payment.currency(), pos_integer}),
+          Transaction.metadata()
+        ) :: Payment.t()
+  def new_payment(inputs, outputs, metadata \\ @zero_metadata)
+
+  def new_payment(inputs, outputs, metadata)
+      when Transaction.is_metadata(metadata) and length(inputs) <= @max_inputs and length(outputs) <= @max_outputs do
+    inputs = Enum.map(inputs, &new_input/1)
+    outputs = Enum.map(outputs, fn output -> new_output(output, @payment_output_type) end)
+    %Transaction.Payment{tx_type: @payment_tx_type, inputs: inputs, outputs: outputs, metadata: metadata}
+  end
+
+  @spec new_payment(
+          list({pos_integer, pos_integer, 0..unquote(@max_outputs - 1)}),
+          list({Crypto.address_t(), Payment.currency(), pos_integer}),
+          Transaction.metadata()
+        ) :: Payment.t()
+  def new_payment_v2(inputs, outputs, metadata \\ @zero_metadata)
+
+  def new_payment_v2(inputs, outputs, metadata)
+      when Transaction.is_metadata(metadata) and length(inputs) <= @max_inputs and length(outputs) <= @max_outputs do
+    inputs = Enum.map(inputs, &new_input/1)
+    outputs = Enum.map(outputs, fn output -> new_output(output, @payment_v2_output_type) end)
+    %Transaction.Payment{tx_type: @payment_v2_tx_type, inputs: inputs, outputs: outputs, metadata: metadata}
+  end
+
+  # `new_input/1` and `new_output/1` are here to just help interpret the short-hand form of inputs outputs when doing
+  # `new/3`
+  defp new_input({blknum, txindex, oindex}), do: Utxo.position(blknum, txindex, oindex)
+
+  defp new_output({owner, currency, amount}, output_type) do
+    %Output{
+      owner: owner,
+      currency: currency,
+      amount: amount,
+      output_type: output_type
+    }
+  end
+end

--- a/apps/omg/lib/omg/wire_format_types.ex
+++ b/apps/omg/lib/omg/wire_format_types.ex
@@ -31,10 +31,11 @@ defmodule OMG.WireFormatTypes do
     3 => OMG.State.Transaction.Fee
   }
 
-  @module_tx_types %{
-    OMG.State.Transaction.Payment => 1,
-    OMG.State.Transaction.Fee => 3
-  }
+  # @module_tx_types %{
+  #   OMG.State.Transaction.Payment => 1,
+  #   OMG.State.Transaction.PaymentV2 => 2,
+  #   OMG.State.Transaction.Fee => 3
+  # }
 
   @input_pointer_type_values %{
     input_pointer_utxo_position: 1
@@ -42,12 +43,14 @@ defmodule OMG.WireFormatTypes do
 
   @output_type_values %{
     output_payment_v1: 1,
-    output_fee_token_claim: 2
+    output_fee_token_claim: 2,
+    output_payment_v2: 3
   }
 
   @output_type_modules %{
     1 => OMG.Output,
-    2 => OMG.Output
+    2 => OMG.Output,
+    3 => OMG.Output
   }
 
   @exit_game_tx_types [
@@ -71,11 +74,11 @@ defmodule OMG.WireFormatTypes do
   @spec tx_type_modules() :: tx_type_to_module_map()
   def tx_type_modules(), do: @tx_type_modules
 
-  @doc """
-  Returns the tx type that is associated with the given module
-  """
-  @spec module_tx_types() :: %{atom() => non_neg_integer()}
-  def module_tx_types(), do: @module_tx_types
+  # @doc """
+  # Returns the tx type that is associated with the given module
+  # """
+  # @spec module_tx_types() :: %{atom() => non_neg_integer()}
+  # def module_tx_types(), do: @module_tx_types
 
   @doc """
   Returns wire format type value of known input pointer type

--- a/apps/omg/lib/omg/wire_format_types.ex
+++ b/apps/omg/lib/omg/wire_format_types.ex
@@ -31,12 +31,6 @@ defmodule OMG.WireFormatTypes do
     3 => OMG.State.Transaction.Fee
   }
 
-  # @module_tx_types %{
-  #   OMG.State.Transaction.Payment => 1,
-  #   OMG.State.Transaction.PaymentV2 => 2,
-  #   OMG.State.Transaction.Fee => 3
-  # }
-
   @input_pointer_type_values %{
     input_pointer_utxo_position: 1
   }
@@ -62,9 +56,6 @@ defmodule OMG.WireFormatTypes do
   @known_input_pointer_types Map.keys(@input_pointer_type_values)
   @known_output_types Map.keys(@output_type_values)
 
-  @spec tx_type_values() :: map()
-  def tx_type_values(), do: @tx_type_values
-
   @doc """
   Returns wire format type value of known transaction type
   """
@@ -76,12 +67,6 @@ defmodule OMG.WireFormatTypes do
   """
   @spec tx_type_modules() :: tx_type_to_module_map()
   def tx_type_modules(), do: @tx_type_modules
-
-  # @doc """
-  # Returns the tx type that is associated with the given module
-  # """
-  # @spec module_tx_types() :: %{atom() => non_neg_integer()}
-  # def module_tx_types(), do: @module_tx_types
 
   @doc """
   Returns wire format type value of known input pointer type

--- a/apps/omg/lib/omg/wire_format_types.ex
+++ b/apps/omg/lib/omg/wire_format_types.ex
@@ -62,6 +62,9 @@ defmodule OMG.WireFormatTypes do
   @known_input_pointer_types Map.keys(@input_pointer_type_values)
   @known_output_types Map.keys(@output_type_values)
 
+  @spec tx_type_values() :: map()
+  def tx_type_values(), do: @tx_type_values
+
   @doc """
   Returns wire format type value of known transaction type
   """

--- a/apps/omg_watcher_info/lib/omg_watcher_info/api/transaction.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/api/transaction.ex
@@ -99,7 +99,9 @@ defmodule OMG.WatcherInfo.API.Transaction do
       [
         create_inputs(inputs),
         create_outputs(outputs),
-        [metadata: metadata || @empty_metadata]
+        [metadata: metadata || @empty_metadata],
+        # TODO: hack for inject tx type 2 forcely
+        [tx_type: 2]
       ]
       |> Enum.concat()
       |> Map.new()

--- a/apps/omg_watcher_info/lib/omg_watcher_info/api/transaction.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/api/transaction.ex
@@ -92,16 +92,15 @@ defmodule OMG.WatcherInfo.API.Transaction do
       %{advice | transactions: Enum.map(txs, fn tx -> Map.put_new(tx, :typed_data, add_type_specs(tx)) end)}
     }
 
-  defp add_type_specs(%{inputs: inputs, outputs: outputs, metadata: metadata}) do
+  defp add_type_specs(tx) do
     alias OMG.TypedDataHash
 
     message =
       [
-        create_inputs(inputs),
-        create_outputs(outputs),
-        [metadata: metadata || @empty_metadata],
-        # TODO: hack for inject tx type 2 forcely
-        [tx_type: 2]
+        create_inputs(tx.inputs),
+        create_outputs(tx.outputs),
+        [metadata: tx.metadata || @empty_metadata],
+        [tx_type: tx.tx_type]
       ]
       |> Enum.concat()
       |> Map.new()

--- a/apps/omg_watcher_info/lib/omg_watcher_info/utxo_selection.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/utxo_selection.ex
@@ -209,28 +209,20 @@ defmodule OMG.WatcherInfo.UtxoSelection do
   end
 
   defp create_raw_transaction(tx_type, inputs, outputs, metadata) do
-    tx_type_values = OMG.WireFormatTypes.tx_type_values()
-
+    # Somehow the API is designed to return nil txbytes instead of claiming that as bad request :(
+    # So we need to return nil here
+    # See the test: "test /transaction.create does not return txbytes when spend owner is not provided"
     case Enum.any?(outputs, &(&1.owner == nil)) do
       true ->
         nil
 
       false ->
-        cond do
-          tx_type == tx_type_values.tx_payment_v1 ->
-            Transaction.Payment.Builder.new_payment(
-              inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
-              outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
-              metadata || @empty_metadata
-            )
-
-          tx_type == tx_type_values.tx_payment_v2 ->
-            Transaction.Payment.Builder.new_payment_v2(
-              inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
-              outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
-              metadata || @empty_metadata
-            )
-        end
+        Transaction.Payment.Builder.new_payment(
+          tx_type,
+          inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
+          outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
+          metadata || @empty_metadata
+        )
     end
   end
 

--- a/apps/omg_watcher_info/lib/omg_watcher_info/utxo_selection.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/utxo_selection.ex
@@ -22,6 +22,7 @@ defmodule OMG.WatcherInfo.UtxoSelection do
   alias OMG.TypedDataHash
   alias OMG.WatcherInfo.DB
 
+  require Logger
   require Transaction
   require Transaction.Payment
 
@@ -205,7 +206,7 @@ defmodule OMG.WatcherInfo.UtxoSelection do
     if Enum.any?(outputs, &(&1.owner == nil)),
       do: nil,
       else:
-        Transaction.Payment.new(
+        Transaction.Payment.Builder.new_payment_v2(
           inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
           outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
           metadata || @empty_metadata

--- a/apps/omg_watcher_info/lib/omg_watcher_info/utxo_selection.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/utxo_selection.ex
@@ -38,6 +38,7 @@ defmodule OMG.WatcherInfo.UtxoSelection do
         }
 
   @type order_t() :: %{
+          tx_type: non_neg_integer(),
           owner: Crypto.address_t(),
           payments: nonempty_list(payment_t()),
           fee: fee_t(),
@@ -72,7 +73,8 @@ defmodule OMG.WatcherInfo.UtxoSelection do
   TODO: seems unocovered by any tests
   """
   @spec create_advice(%{Transaction.Payment.currency() => list(%DB.TxOutput{})}, order_t()) :: advice_t()
-  def create_advice(utxos, %{owner: owner, payments: payments, fee: fee} = order) do
+  def create_advice(utxos, order) do
+    %{tx_type: tx_type, owner: owner, payments: payments, fee: fee} = order
     needed_funds = needed_funds(payments, fee)
     token_utxo_selection = select_utxo(utxos, needed_funds)
 
@@ -84,7 +86,7 @@ defmodule OMG.WatcherInfo.UtxoSelection do
 
       if utxo_count <= Transaction.Payment.max_inputs(),
         do: create_transaction(funds, order) |> respond(:complete),
-        else: create_merge(owner, funds) |> respond(:intermediate)
+        else: create_merge(tx_type, owner, funds) |> respond(:intermediate)
     end
   end
 
@@ -140,7 +142,9 @@ defmodule OMG.WatcherInfo.UtxoSelection do
       else: {:error, {:insufficient_funds, missing_funds}}
   end
 
-  defp create_transaction(utxos_per_token, %{owner: owner, payments: payments, metadata: metadata, fee: fee}) do
+  defp create_transaction(utxos_per_token, order) do
+    %{tx_type: tx_type, owner: owner, payments: payments, metadata: metadata, fee: fee} = order
+
     rests =
       utxos_per_token
       |> Stream.map(fn {token, utxos} ->
@@ -166,10 +170,11 @@ defmodule OMG.WatcherInfo.UtxoSelection do
         {:error, :empty_transaction}
 
       true ->
-        raw_tx = create_raw_transaction(inputs, outputs, metadata)
+        raw_tx = create_raw_transaction(tx_type, inputs, outputs, metadata)
 
         {:ok,
          %{
+           tx_type: tx_type,
            inputs: inputs,
            outputs: outputs,
            fee: fee,
@@ -180,7 +185,7 @@ defmodule OMG.WatcherInfo.UtxoSelection do
     end
   end
 
-  defp create_merge(owner, utxos_per_token) do
+  defp create_merge(tx_type, owner, utxos_per_token) do
     utxos_per_token
     |> Enum.map(fn {token, utxos} ->
       Stream.chunk_every(utxos, Transaction.Payment.max_outputs())
@@ -191,6 +196,7 @@ defmodule OMG.WatcherInfo.UtxoSelection do
 
         inputs ->
           create_transaction([{token, inputs}], %{
+            tx_type: tx_type,
             fee: %{amount: 0, currency: token},
             metadata: @empty_metadata,
             owner: owner,
@@ -202,15 +208,30 @@ defmodule OMG.WatcherInfo.UtxoSelection do
     |> Enum.map(fn {:ok, tx} -> tx end)
   end
 
-  defp create_raw_transaction(inputs, outputs, metadata) do
-    if Enum.any?(outputs, &(&1.owner == nil)),
-      do: nil,
-      else:
-        Transaction.Payment.Builder.new_payment_v2(
-          inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
-          outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
-          metadata || @empty_metadata
-        )
+  defp create_raw_transaction(tx_type, inputs, outputs, metadata) do
+    tx_type_values = OMG.WireFormatTypes.tx_type_values()
+
+    case Enum.any?(outputs, &(&1.owner == nil)) do
+      true ->
+        nil
+
+      false ->
+        cond do
+          tx_type == tx_type_values.tx_payment_v1 ->
+            Transaction.Payment.Builder.new_payment(
+              inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
+              outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
+              metadata || @empty_metadata
+            )
+
+          tx_type == tx_type_values.tx_payment_v2 ->
+            Transaction.Payment.Builder.new_payment_v2(
+              inputs |> Enum.map(&{&1.blknum, &1.txindex, &1.oindex}),
+              outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
+              metadata || @empty_metadata
+            )
+        end
+    end
   end
 
   defp create_txbytes(tx) do

--- a/apps/omg_watcher_rpc/lib/web/validators/order.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/order.ex
@@ -25,6 +25,8 @@ defmodule OMG.WatcherRPC.Web.Validator.Order do
   alias OMG.Utils.HttpRPC.Validator.Base
   alias OMG.WatcherInfo.UtxoSelection
 
+  @default_tx_type 1
+
   @doc """
   Parses and validates request body
   """
@@ -35,9 +37,14 @@ defmodule OMG.WatcherRPC.Web.Validator.Order do
          {:ok, fee} <- expect(params, "fee", map: &parse_fee/1),
          {:ok, payments} <- expect(params, "payments", list: &parse_payment/1),
          {:ok, payments} <- fills_in_outputs?(payments),
+         {:ok, tx_type} = expect(params, "tx_type", [:integer, :optional]),
          :ok <- ensure_not_self_transaction(owner, payments) do
+      # keep this optional args for backward competibility
+      tx_type = tx_type || @default_tx_type
+
       {:ok,
        %{
+         tx_type: tx_type,
          owner: owner,
          payments: payments,
          fee: fee,

--- a/apps/omg_watcher_rpc/lib/web/validators/order.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/order.ex
@@ -24,8 +24,9 @@ defmodule OMG.WatcherRPC.Web.Validator.Order do
   alias OMG.State.Transaction
   alias OMG.Utils.HttpRPC.Validator.Base
   alias OMG.WatcherInfo.UtxoSelection
+  alias OMG.WireFormatTypes
 
-  @default_tx_type 1
+  @default_tx_type WireFormatTypes.tx_type_for(:tx_payment_v1)
 
   @doc """
   Parses and validates request body

--- a/apps/omg_watcher_rpc/lib/web/validators/typed_data_signed.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/typed_data_signed.ex
@@ -41,7 +41,14 @@ defmodule OMG.WatcherRPC.Web.Validator.TypedDataSigned do
          inputs when is_list(inputs) <- parse_inputs(msg),
          outputs when is_list(outputs) <- parse_outputs(msg),
          {:ok, metadata} <- expect(msg, "metadata", :hash) do
-      {:ok, Transaction.Payment.new(inputs, outputs, metadata)}
+      {:ok, tx_type} = expect(msg, "tx_type", [:integer, :optional])
+
+      case tx_type do
+        nil -> {:ok, Transaction.Payment.Builder.new_payment(inputs, outputs, metadata)}
+        # TODO: remove magic number
+        1 -> {:ok, Transaction.Payment.Builder.new_payment(inputs, outputs, metadata)}
+        2 -> {:ok, Transaction.Payment.Builder.new_payment_v2(inputs, outputs, metadata)}
+      end
     end
   end
 

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
@@ -1772,6 +1772,9 @@ paths:
               title: CreateTransactionsBodySchema
               type: object
               properties:
+                tx_type:
+                  type: integer
+                  format: int256
                 owner:
                   type: string
                 payments:

--- a/priv/cabbage/apps/itest/lib/client.ex
+++ b/priv/cabbage/apps/itest/lib/client.ex
@@ -32,6 +32,7 @@ defmodule Itest.Client do
   require Logger
 
   @gas 180_000
+  @payment_v1_tx_type 1
 
   def deposit(amount_in_wei, output_address, vault_address, currency \\ Currency.ether()) do
     deposit_transaction = deposit_transaction(amount_in_wei, output_address, currency)
@@ -52,8 +53,15 @@ defmodule Itest.Client do
     {:ok, receipt_hash}
   end
 
-  def create_transaction(amount_in_wei, input_address, output_address, currency \\ Currency.ether()) do
+  def create_transaction(
+        amount_in_wei,
+        input_address,
+        output_address,
+        currency \\ Currency.ether(),
+        tx_type \\ @payment_v1_tx_type
+      ) do
     transaction = %CreateTransactionsBodySchema{
+      tx_type: tx_type,
       owner: input_address,
       payments: [
         %TransactionCreatePayments{

--- a/priv/cabbage/apps/itest/test/features/payment_v2.feature
+++ b/priv/cabbage/apps/itest/test/features/payment_v2.feature
@@ -1,9 +1,9 @@
 Feature: Payment V2 transaction
 
-  Scenario: 2 entities exchange ETH with payment v1 and v2
-    When they deposit "4" ETH to the root chain
-    Then they should have "4" ETH on the child chain
-    When they send others "1" ETH on the child chain with payment v1
-    Then others should have "1" ETH on the child chain
-    When they send others "2" ETH on the child chain with payment v2
-    Then others should have "3" ETH on the child chain
+  Scenario: Alice sends Bob ETH with payment v1 and v2
+    When Alice deposits "4" ETH to the root chain
+    Then Alice should have "4" ETH on the child chain
+    When Alice sends Bob "1" ETH on the child chain with payment v1
+    Then Bob should have "1" ETH on the child chain
+    When Alice sends Bob "2" ETH on the child chain with payment v2
+    Then Bob should have "3" ETH on the child chain

--- a/priv/cabbage/apps/itest/test/features/payment_v2.feature
+++ b/priv/cabbage/apps/itest/test/features/payment_v2.feature
@@ -1,0 +1,9 @@
+Feature: Payment V2 transaction
+
+  Scenario: 2 entities exchange ETH with payment v1 and v2
+    When they deposit "4" ETH to the root chain
+    Then they should have "4" ETH on the child chain
+    When they send others "1" ETH on the child chain with payment v1
+    Then others should have "1" ETH on the child chain
+    When they send others "2" ETH on the child chain with payment v2
+    Then others should have "3" ETH on the child chain

--- a/priv/cabbage/apps/itest/test/itest/payment_v2_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/payment_v2_test.exs
@@ -24,8 +24,10 @@ defmodule PaymentV2Test do
 
   setup do
     [alice, bob] =
-      Account.take_accounts(2)
-      |> Enum.map(fn {account, pkey} -> %{account: account, pkey: pkey} end)
+      Enum.map(
+        Account.take_accounts(2),
+        fn {account, pkey} -> %{account: account, pkey: pkey} end
+      )
 
     %{alice: alice, bob: bob}
   end

--- a/priv/cabbage/apps/itest/test/itest/transactions_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/transactions_test.exs
@@ -24,7 +24,7 @@ defmodule TransactionsTests do
 
   # needs to be an even number, because we split the accounts in half, the first half sends ETH
   # to the other half
-  @num_accounts 4
+  @num_accounts 2
   setup do
     {alices, bobs} =
       @num_accounts
@@ -88,6 +88,9 @@ defmodule TransactionsTests do
             bob_account
           )
 
+        _ = Logger.warn("WHYYYYYY")
+        _ = Logger.warn(inspect(typed_data))
+        _ = Logger.warn(inspect(sign_hash))
         # Alice needs to sign 2 inputs of 1 Eth, 1 for Bob and 1 for the fees
         _ = Client.submit_transaction(typed_data, sign_hash, [alice_pkey, alice_pkey])
       end,

--- a/priv/dev-artifacts/fee_specs.dev.json
+++ b/priv/dev-artifacts/fee_specs.dev.json
@@ -10,5 +10,17 @@
             "symbol": "ETH",
             "type": "fixed"
         }
+    },
+    "2": {
+        "0x0000000000000000000000000000000000000000": {
+            "amount": 1,
+            "pegged_amount": null,
+            "pegged_currency": null,
+            "pegged_subunit_to_unit": null,
+            "subunit_to_unit": 1000000000000000000,
+            "updated_at": "2019-01-01T10:10:00+00:00",
+            "symbol": "ETH",
+            "type": "fixed"
+        }
     }
 }


### PR DESCRIPTION
:clipboard: closes https://github.com/omgnetwork/new-tx-type-poc/issues/16

## Overview

Though the main goal is to be a bit TDD so have e2e test. However, without making change to existing code base it would not be able to run the test. I did try to make some minimum change to just let it work. 

There are separate issue tracking the implementation to make the code looks better.

Exit event testing is out of scope of this PR. It is also waiting on https://github.com/omgnetwork/elixir-omg/pull/1573

## Changes

- Add payment v2 transfer cabbage test.
- watcher info `/transaction.create` now accept `tx_type` as a param (optional).
- Add payment v2 tx type and output type.

## Testing

Add cabbage test. run `mix test test/itest/payment_v2_test.exs`
