### PR TITLE
remove trace decorator from OMG.WatcherInfo.DB.EthEvent.get/1

### DIFF
--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/eth_event.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/eth_event.ex
@@ -145,7 +145,6 @@ defmodule OMG.WatcherInfo.DB.EthEvent do
   Retrieves event by `root_chain_txhash_event` (unique identifier). Preload txoutputs in a single query as there will not be a large number of them.
   """
   @spec get(binary()) :: %__MODULE__{}
-  @decorate trace(service: :ecto, type: :db, tracer: OMG.WatcherInfo.Tracer)
   def get(root_chain_txhash_event) do
     DB.Repo.one(
       from(ethevent in base_query(),


### PR DESCRIPTION
This function is used in other traced functions in the same module so
errors appear:

```
2020-07-13 15:08:47.614 [error] module=Spandex function=start_trace/2
trace_id=31645604945997287 span_id=8193285015445073632 ⋅Tried to start
a trace over top of another trace.⋅
2020-07-13 15:08:47.634 [error] module=Spandex function=finish_trace/1
trace_id=4830626519991268780 span_id=5830755077416789889 ⋅Tried to
finish a trace without an active trace.
```

Because the function is decorated twice. get/1 is used only inside of
other traced functions and in tests.