### PR TITLE
Add missing clause on witness validation check

### DIFF
--- a/apps/omg/lib/omg/state/transaction/witness.ex
+++ b/apps/omg/lib/omg/state/transaction/witness.ex
@@ -27,6 +27,7 @@ defmodule OMG.State.Transaction.Witness do
   Pre-check done after decoding to quickly assert whether the witness has one of valid forms
   """
   def valid?(witness) when is_binary(witness), do: signature_length?(witness)
+  def valid?(_), do: false
 
   @doc """
   Prepares the witness to be quickly used in stateful validation

--- a/apps/omg/test/omg/state/transaction/recovered_test.exs
+++ b/apps/omg/test/omg/state/transaction/recovered_test.exs
@@ -148,6 +148,11 @@ defmodule OMG.State.Transaction.RecoveredTest do
                  ExRLP.encode([ExPlasma.payment_v1(), @payment_tx_type, inputs, outputs, 0, <<0::256>>])
                )
 
+      assert {:error, :malformed_witnesses} ==
+              Transaction.Recovered.recover_from(
+                ExRLP.encode([[sigs], @payment_tx_type, inputs, outputs, 0, <<0::256>>])
+              )
+
       assert {:error, :malformed_inputs} =
                Transaction.Recovered.recover_from(ExRLP.encode([sigs, @payment_tx_type, 42, outputs, 0, <<0::256>>]))
 

--- a/apps/omg/test/omg/state/transaction/recovered_test.exs
+++ b/apps/omg/test/omg/state/transaction/recovered_test.exs
@@ -149,9 +149,9 @@ defmodule OMG.State.Transaction.RecoveredTest do
                )
 
       assert {:error, :malformed_witnesses} ==
-              Transaction.Recovered.recover_from(
-                ExRLP.encode([[sigs], @payment_tx_type, inputs, outputs, 0, <<0::256>>])
-              )
+               Transaction.Recovered.recover_from(
+                 ExRLP.encode([[sigs], @payment_tx_type, inputs, outputs, 0, <<0::256>>])
+               )
 
       assert {:error, :malformed_inputs} =
                Transaction.Recovered.recover_from(ExRLP.encode([sigs, @payment_tx_type, 42, outputs, 0, <<0::256>>]))

--- a/apps/omg/test/omg/state/transaction/witness_test.exs
+++ b/apps/omg/test/omg/state/transaction/witness_test.exs
@@ -21,15 +21,15 @@ defmodule OMG.State.Transaction.WitnessTest do
 
   describe "valid?/1" do
     test "returns true when is binary and 65 bytes long" do
-      assert Witness.valid?(<<0::520>>) == true
+      assert Witness.valid?(<<0::520>>)
     end
 
     test "returns false when not a binary" do
-      assert Witness.valid?([<<0>>]) == false
+      refute Witness.valid?([<<0>>])
     end
 
     test "returns false when not 65 bytes long" do
-      assert Witness.valid?(<<0>>) == false
+      refute Witness.valid?(<<0>>)
     end
   end
 end

--- a/apps/omg/test/omg/state/transaction/witness_test.exs
+++ b/apps/omg/test/omg/state/transaction/witness_test.exs
@@ -1,0 +1,35 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Transaction.WitnessTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias OMG.State.Transaction.Witness
+
+  describe "valid?/1" do
+    test "returns true when is binary and 65 bytes long" do
+      assert Witness.valid?(<<0::520>>) == true
+    end
+
+    test "returns false when not a binary" do
+      assert Witness.valid?([<<0>>]) == false
+    end
+
+    test "returns false when not 65 bytes long" do
+      assert Witness.valid?(<<0>>) == false
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/omgnetwork/elixir-omg/issues/1158

Fixes a crash when given an array of array of RLP encoded signatures.