### PR TITLE
Fix fee adapter to accept decimal value in fee rules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "priv/cabbage"]
 	path = priv/cabbage
 	url = git@github.com:omgnetwork/specs.git
-        branch = init-specs
+        branch = master

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
@@ -86,7 +86,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
   defp validate_positive_amount(_amount, error), do: {:error, error}
 
   defp validate_optional_positive_amount(nil, _error), do: {:ok, nil}
-  defp validate_optional_positive_amount(amount, _error) when is_integer(amount) and amount > 0, do: {:ok, amount}
+  defp validate_optional_positive_amount(amount, _error) when amount > 0, do: {:ok, amount}
   defp validate_optional_positive_amount(_amount, error), do: {:error, error}
 
   defp validate_pegged_currency(nil), do: {:ok, nil}
@@ -122,5 +122,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
   end
 
   defp validate_fee_type("fixed"), do: {:ok, :fixed}
+  defp validate_fee_type("pegged"), do: {:ok, :pegged}
   defp validate_fee_type(_), do: {:error, :unsupported_fee_type}
+
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
@@ -62,7 +62,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
          {:ok, pegged_amount} <- validate_optional_positive_amount(pegged_amount, :invalid_pegged_amount),
          {:ok, pegged_currency} <- validate_pegged_currency(pegged_currency),
          {:ok, pegged_subunit_to_unit} <-
-           validate_optional_positive_amount(pegged_subunit_to_unit, :invalid_pegged_subunit_to_unit),
+           validate_optional_positive_integer_amount(pegged_subunit_to_unit, :invalid_pegged_subunit_to_unit),
          :ok <- validate_pegged_fields(pegged_currency, pegged_amount, pegged_subunit_to_unit),
          {:ok, updated_at} <- validate_updated_at(updated_at),
          {:ok, fee_type} <- validate_fee_type(fee_type) do
@@ -84,6 +84,13 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
 
   defp validate_positive_amount(amount, _error) when is_integer(amount) and amount > 0, do: {:ok, amount}
   defp validate_positive_amount(_amount, error), do: {:error, error}
+
+  defp validate_optional_positive_integer_amount(nil, _error), do: {:ok, nil}
+
+  defp validate_optional_positive_integer_amount(amount, _error) when is_integer(amount) and amount > 0,
+    do: {:ok, amount}
+
+  defp validate_optional_positive_integer_amount(_amount, error), do: {:error, error}
 
   defp validate_optional_positive_amount(nil, _error), do: {:ok, nil}
   defp validate_optional_positive_amount(amount, _error) when amount > 0, do: {:ok, amount}

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
@@ -124,5 +124,4 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
   defp validate_fee_type("fixed"), do: {:ok, :fixed}
   defp validate_fee_type("pegged"), do: {:ok, :pegged}
   defp validate_fee_type(_), do: {:error, :unsupported_fee_type}
-
 end

--- a/apps/omg_child_chain/test/omg_child_chain/fees/json_single_spec_parser_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/json_single_spec_parser_test.exs
@@ -66,6 +66,22 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
               }} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
+    test "returns ok when given decimal to pegged_amount" do
+      spec = Map.put(@valid_spec, "pegged_amount", 0.33)
+
+      assert {:ok,
+              %{
+                token: @eth,
+                amount: 1,
+                subunit_to_unit: 1_000_000_000_000_000_000,
+                pegged_amount: 0.33,
+                pegged_currency: "USD",
+                pegged_subunit_to_unit: 100,
+                updated_at: "2019-01-01T10:10:00+00:00" |> DateTime.from_iso8601() |> elem(1),
+                type: :fixed
+              }} == JSONSingleSpecParser.parse({@eth_hex, spec})
+    end
+
     test "returns an `invalid_pegged_fields` error when given a nil pegged_amount alone" do
       spec = Map.put(@valid_spec, "pegged_amount", nil)
 
@@ -82,6 +98,12 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
       spec = Map.put(@valid_spec, "pegged_subunit_to_unit", nil)
 
       assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse({@eth_hex, spec})
+    end
+
+    test "returns an `invalid_pegged_subunit_to_unit` error when given a decimal pegged_subunit_to_unit" do
+      spec = Map.put(@valid_spec, "pegged_subunit_to_unit", 0.33)
+
+      assert {:error, :invalid_pegged_subunit_to_unit} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_fee_spec` error when given an invalid map" do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,8 +100,7 @@ services:
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
       - ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
       - FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
-      - FEE_ADAPTER=feed
-      - FEE_FEED_URL=host.docker.internal:4000/api/v1
+      - FEE_ADAPTER=file
       - STORED_FEE_UPDATE_INTERVAL_MINUTES=1
       - FEE_CHANGE_TOLERANCE_PERCENT=1
       - FEE_SPECS_FILE_PATH=/dev-artifacts/fee_specs.dev.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,8 @@ services:
       - FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
       - FEE_ADAPTER=feed
       - FEE_FEED_URL=host.docker.internal:4000/api/v1
-      - STORED_FEE_UPDATE_INTERVAL_MINUTES=5
-      - FEE_CHANGE_TOLERANCE_PERCENT=10
+      - STORED_FEE_UPDATE_INTERVAL_MINUTES=1
+      - FEE_CHANGE_TOLERANCE_PERCENT=1
       - FEE_SPECS_FILE_PATH=/dev-artifacts/fee_specs.dev.json
       - FEE_BUFFER_DURATION_MS=30000
       - LOGGER_BACKEND=console

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,10 @@ services:
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
       - ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
       - FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
-      - FEE_ADAPTER=file
+      - FEE_ADAPTER=feed
+      - FEE_FEED_URL=host.docker.internal:4000/api/v1
+      - STORED_FEE_UPDATE_INTERVAL_MINUTES=5
+      - FEE_CHANGE_TOLERANCE_PERCENT=10
       - FEE_SPECS_FILE_PATH=/dev-artifacts/fee_specs.dev.json
       - FEE_BUFFER_DURATION_MS=30000
       - LOGGER_BACKEND=console


### PR DESCRIPTION
## Overview
pegged amount now can be decimal point, we add that and also enable `pegged` type

Describe what your Pull Request is about in a few sentences.

## Changes

- remove `integer` validation on `validate_optional_positive_amount`
- add default value for fee interval fetching
## Testing

- run test normally
