### PR TITLE
debug: enable debug log in dev

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :logger, level: :debug
+
 config :logger,
   backends: [:console, Sentry.LoggerBackend]
 


### PR DESCRIPTION
Is this the right way to enable debug log?

Trying to understand what is the cause of the 502 response. This commit enables the debug log for dev env. Hopefully the Plug.Logger would log the requests.
    
ref: https://github.com/omgnetwork/devops/issues/373