### PR TITLE
chore: increase timeouts for childchain healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,43 @@ mix deps.get
 mix test
 ```
 
+## Running reorg cabbage tests
+
+Reorg tests test different assumptions against chain reorgs. They also use the same submodule as regular integration cabbage tests.
+
+Fetch submodule:
+```bash
+git submodule init
+git submodule update --remote
+```
+
+Create a directory for geth nodes:
+```bash
+mkdir data1 && chmod 777 data1 && mkdir data2 && chmod 777 data2 && mkdir data && chmod 777 data
+```
+
+Make services:
+```bash
+make docker-child_chain
+make docker-watcher
+make docker-watcher_info
+```
+
+Start geth nodes and postgres:
+```bash
+cd priv/cabbage
+make start_daemon_services_reorg-2
+```
+
+Build the integration tests project and run reorg tests:
+```bash
+cd priv/cabbage
+make install
+make generate_api_code
+mix deps.get
+REORG=true mix test --only reorg --trace
+```
+
 # Working with API Spec's
 
 This repo contains `gh-pages` branch intended to host [Swagger-based](https://docs.omg.network/elixir-omg/) API specification.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     volumes:
       - ./data:/data
     healthcheck:
-      test: curl geth:8545
+      test: curl localhost:8545
       interval: 5s
       timeout: 3s
       retries: 5
@@ -117,11 +117,11 @@ services:
       - ./data:/data
       - ./priv/dev-artifacts:/dev-artifacts
     healthcheck:
-      test: curl childchain:9656
+      test: curl localhost:9656
       interval: 30s
-      timeout: 1s
+      timeout: 10s
       retries: 5
-      start_period: 30s
+      start_period: 60s
     depends_on:
       nginx:
         condition: service_healthy
@@ -160,7 +160,7 @@ services:
     volumes:
       - ./data:/data
     healthcheck:
-      test: curl watcher:7434
+      test: curl localhost:7434
       interval: 30s
       timeout: 1s
       retries: 5
@@ -203,7 +203,7 @@ services:
     volumes:
       - ./data:/data
     healthcheck:
-      test: curl watcher_info:7534
+      test: curl localhost:7534
       interval: 30s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
## Overview

On the latest master I can't start reorg docker-compose locally, because it fails with the childchain is not healthy error:
```
Creating elixir-omg_postgres_1 ... done
Creating elixir-omg_geth_1     ... done
Creating geth-1                ... done
Creating geth-2                ... done
Creating nginx                 ... done
Creating childchain            ... done

ERROR: for watcher  Container "d7e5a929f9d7" is unhealthy.

ERROR: for watcher_info  Container "d7e5a929f9d7" is unhealthy.
```

I increased timeouts for childchain healthchecks. After that docker-compose starts without issues.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Increase the timeouts for childchain healthchecks
- Use localhost in healthchecks
- Add reorg tests to the README
