### PR TITLE
account.get_exitable_utxos is unaware of in-flight exited inputs

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/api/account.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/account.ex
@@ -31,10 +31,16 @@ defmodule OMG.Watcher.API.Account do
 
     # PaymentExitInfo.all_exit_infos() takes a while.
     {:ok, standard_exits} = PaymentExitInfo.all_exit_infos()
-    active_standard_exiting_utxos = OMG.Watcher.ExitProcessor.Core.active_standard_exiting_utxos(standard_exits)
+    {:ok, in_flight_exits} = PaymentExitInfo.all_in_flight_exits_infos()
+
+    active_exiting_utxos =
+      MapSet.union(
+        OMG.Watcher.ExitProcessor.Core.active_standard_exiting_utxos(standard_exits),
+        OMG.Watcher.ExitProcessor.Core.active_in_flight_exiting_inputs(in_flight_exits)
+      )
 
     # active standard exiting utxos are excluded
-    filter_standard_exiting_utxos(standard_exitable_utxos, active_standard_exiting_utxos)
+    filter_standard_exiting_utxos(standard_exitable_utxos, active_exiting_utxos)
   end
 
   defp filter_standard_exiting_utxos(standard_exitable_utxos, active_standard_exiting_utxos) do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -582,6 +582,18 @@ defmodule OMG.Watcher.ExitProcessor.Core do
     |> MapSet.new()
   end
 
+  @doc """
+  Returns a set of input's utxo positions for in-flight exiting transactions
+  """
+  @spec active_in_flight_exiting_inputs(list(map)) :: MapSet.t(Utxo.Position.t())
+  def active_in_flight_exiting_inputs(db_exits) do
+    db_exits
+    |> Stream.map(&InFlightExitInfo.from_db_kv/1)
+    |> Stream.filter(fn {_, exit_info} -> exit_info.is_active end)
+    |> Enum.flat_map(fn {_, exit_info} -> exit_info.input_utxos_pos end)
+    |> MapSet.new()
+  end
+
   defp prepare_in_flight_exit({txhash, ife_info}) do
     %{tx: tx, eth_height: eth_height} = ife_info
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -295,12 +295,6 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
   end
 
   describe "active_in_flight_exiting_inputs" do
-    test "in-flight exit info db value is formed correctly" do
-      ife_exit_info = prepare_fake_ife_db_kv(true, [])
-
-      assert {<<1>>, %InFlightExitInfo{}} = InFlightExitInfo.from_db_kv({<<1>>, ife_exit_info})
-    end
-
     test "returns a set of exiting utxo positions" do
       expected_utxos = [Utxo.position(2001, 0, 0), Utxo.position(2002, 0, 0)]
 
@@ -317,22 +311,28 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       signed_tx_map = %{raw_tx: raw_tx_map, sigs: []}
       utxo_pos = Utxo.position(0, 0, 0)
 
-      %{
-        tx: signed_tx_map,
-        exit_map: %{},
-        tx_pos: utxo_pos,
-        oldest_competitor: utxo_pos,
-        contract_id: <<1>>,
-        timestamp: 0,
-        eth_height: 100,
-        relevant_from_blknum: 0,
-        input_txs: [],
-        input_utxos_pos: [],
-        is_canonical: true,
-        is_active: true
-      }
-      |> Map.update!(:is_active, fn _ -> is_active end)
-      |> Map.update!(:input_utxos_pos, fn _ -> utxos_pos end)
+      db_value_map =
+        %{
+          tx: signed_tx_map,
+          exit_map: %{},
+          tx_pos: utxo_pos,
+          oldest_competitor: utxo_pos,
+          contract_id: <<1>>,
+          timestamp: 0,
+          eth_height: 100,
+          relevant_from_blknum: 0,
+          input_txs: [],
+          input_utxos_pos: [],
+          is_canonical: true,
+          is_active: true
+        }
+        |> Map.update!(:is_active, fn _ -> is_active end)
+        |> Map.update!(:input_utxos_pos, fn _ -> utxos_pos end)
+
+      # sanity check - we need above date to be parsed correctly
+      assert {<<1>>, %InFlightExitInfo{}} = InFlightExitInfo.from_db_kv({<<1>>, db_value_map})
+
+      db_value_map
     end
   end
 end


### PR DESCRIPTION
Solves omgnetwork/private-issues#41

## Overview

Assuming standard IFE case where in-flight transaction is not submitted. This means transaction's outputs don't exist and inputs regardless transaction's canonicity cannot be standard-exited. Therefore they are being filtered from the result of the `account.get_exitable_utxos` endpoint 

## Changes

Inputs of the transaction in-flight are being removed from the results returned by the `account.get_exitable_utxos` endpoint 

## Testing

Specs test demonstrate the feature https://github.com/omgnetwork/specs/pull/4
