### PR TITLE
auto trigger chart version bump

### DIFF
--- a/.circleci/ci_increase_chart_version.sh
+++ b/.circleci/ci_increase_chart_version.sh
@@ -12,25 +12,18 @@ Required env vars:
 """
 
 set -e
+set -x
 
 increase_chart_version() {
     APP_VERSION="${CIRCLE_TAG#*v}"
 
-    curl --location --request POST 'https://api.github.com/repos/omgnetwork/${HELM_CHART_REPO}/dispatches' \
+    echo "increase chart version for chart: ${CHART_NAME} with APP_VERSION: ${APP_VERSION}"
+
+    curl --location --request POST 'https://api.github.com/repos/omgnetwork/'${HELM_CHART_REPO}'/dispatches' \
     --header 'Accept: application/vnd.github.v3+json' \
-    --header 'authorization: token ${GITHUB_API_TOKEN}' \
+    --header 'authorization: token '${GITHUB_API_TOKEN}'' \
     --header 'Content-Type: application/json' \
-    --data-raw '{"event_type": "increase-chart-version", "client_payload": { "chart_name": ${CHART_NAME}, "app_version": ${APP_VERSION} }}'
+    --data-raw '{"event_type": "increase-chart-version", "client_payload": { "chart_name": "'${CHART_NAME}'", "app_version": "'${APP_VERSION}'" }}'
 }
 
-if [[ -n "$CIRCLE_TAG" ]]; then
-    # if the tag start with a version. eg. `v1.0.3-pre.0`
-    # otherwise it is not a release tag
-    if [[ $CIRCLE_TAG =~ ^v.* ]]; then
-        increase_chart_version
-    else
-        echo "Not tag for release version, skipping increase chart version..."
-    fi
-else
-    echo "There is no circle CI tag, skipping increase chart version...."
-fi
+increase_chart_version

--- a/.circleci/ci_increase_chart_version.sh
+++ b/.circleci/ci_increase_chart_version.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+"""
+This is the script that would send a dispatch event to the helm chart repo to
+auto increase chart version.
+
+Required env vars:
+- CIRCLE_TAG
+- CHART_NAME
+- HELM_CHART_REPO
+- GITHUB_API_TOKEN
+"""
+
+set -e
+
+increase_chart_version() {
+    APP_VERSION="${CIRCLE_TAG#*v}"
+
+    curl --location --request POST 'https://api.github.com/repos/omgnetwork/${HELM_CHART_REPO}/dispatches' \
+    --header 'Accept: application/vnd.github.v3+json' \
+    --header 'authorization: token ${GITHUB_API_TOKEN}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"event_type": "increase-chart-version", "client_payload": { "chart_name": ${CHART_NAME}, "app_version": ${APP_VERSION} }}'
+}
+
+if [[ -n "$CIRCLE_TAG" ]]; then
+    # if the tag start with a version. eg. `v1.0.3-pre.0`
+    # otherwise it is not a release tag
+    if [[ $CIRCLE_TAG =~ ^v.* ]]; then
+        increase_chart_version
+    else
+        echo "Not tag for release version, skipping increase chart version..."
+    fi
+else
+    echo "There is no circle CI tag, skipping increase chart version...."
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,7 +774,7 @@ jobs:
     environment:
       CHART_NAME: childchain
       HELM_CHART_REPO: helm-development
-      GITHUB_API_TOKEN: HOUSE_KEEPER_BOT_TOKEN
+      # GITHUB_API_TOKEN: ${HOUSE_KEEPER_BOT_TOKEN}
     steps:
       - checkout
       - run: sh .circleci/ci_increase_chart_version.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,9 +770,28 @@ jobs:
   increase_chart_version_childchain:
     docker:
       - image: cimg/base:2020.01
-      # image: ubuntu-1604:201903-01
     environment:
       CHART_NAME: childchain
+      HELM_CHART_REPO: helm-development-boolafish-playground
+    steps:
+      - checkout
+      - run: sh .circleci/ci_increase_chart_version.sh
+
+  increase_chart_version_watcher:
+    docker:
+      - image: cimg/base:2020.01
+    environment:
+      CHART_NAME: watcher
+      HELM_CHART_REPO: helm-development-boolafish-playground
+    steps:
+      - checkout
+      - run: sh .circleci/ci_increase_chart_version.sh
+
+  increase_chart_version_watcher_info:
+    docker:
+      - image: cimg/base:2020.01
+    environment:
+      CHART_NAME: watcher-info
       HELM_CHART_REPO: helm-development-boolafish-playground
     steps:
       - checkout
@@ -987,6 +1006,13 @@ workflows:
             tags:
               only:
                 - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - increase_chart_version_watcher:
+        # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          filters: *only_release_tag
+
+      - increase_chart_version_watcher_info:
+        # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          filters: *only_release_tag
       # Release deploy to development in case of master branch.
       # - deploy_child_chain:
       #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,6 +767,18 @@ jobs:
           path: current_release/
       - run: IMAGE_NAME=$WATCHER_INFO_IMAGE_NAME sh .circleci/ci_publish.sh
 
+  increase_chart_version_childchain:
+    machine:
+      # image: cimg/base:2020.01
+      image: ubuntu-1604:201903-01
+    environment:
+      CHART_NAME: childchain
+      HELM_CHART_REPO: helm-development
+      GITHUB_API_TOKEN: HOUSE_KEEPER_BOT_TOKEN
+    steps:
+      - checkout
+      - run: sh .circleci/ci_increase_chart_version.sh
+
   deploy_child_chain:
     executor: deployer
     steps:
@@ -853,137 +865,140 @@ workflows:
           requires: [build]
   build-test-deploy:
     jobs:
-      - build:
-          filters: &all_branches_and_tags
-            branches:
-              only: /.+/
-            tags:
-              only: /.+/
-      - test_barebone_release:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - notify_services:
-          requires: [deploy_watcher, deploy_watcher_info, deploy_child_chain]
-          filters:
-            branches:
-              only:
-                - master
-      - coveralls_report:
-          requires:
-            - child_chain_coveralls_and_integration_tests
-            - watcher_coveralls_and_integration_tests
-            - watcher_info_coveralls_and_integration_tests
-            - common_coveralls_and_integration_tests
-            - test
-      - child_chain_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - watcher_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - watcher_info_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - common_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - test_docker_compose_release:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - test_docker_compose_reorg:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - audit_deps:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - lint:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - lint_version:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - sobelow:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - dialyzer:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - test:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - property_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      # Publish in case of master branch, version branches and version tags.
-      - publish_child_chain:
-          requires:
-            [
-              child_chain_coveralls_and_integration_tests,
-              watcher_coveralls_and_integration_tests,
-              watcher_info_coveralls_and_integration_tests,
-              common_coveralls_and_integration_tests,
-              test,
-              property_tests,
-              dialyzer,
-              lint,
-              lint_version,
-              audit_deps
-            ]
-          filters: &master_and_version_branches_and_all_tags
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
-      - publish_watcher:
-          requires:
-            [
-              child_chain_coveralls_and_integration_tests,
-              watcher_coveralls_and_integration_tests,
-              watcher_info_coveralls_and_integration_tests,
-              common_coveralls_and_integration_tests,
-              test,
-              property_tests,
-              dialyzer,
-              lint,
-              lint_version,
-              audit_deps
-            ]
-          filters: *master_and_version_branches_and_all_tags
-      - publish_watcher_info:
-          requires:
-            [
-              child_chain_coveralls_and_integration_tests,
-              watcher_coveralls_and_integration_tests,
-              watcher_info_coveralls_and_integration_tests,
-              common_coveralls_and_integration_tests,
-              test,
-              property_tests,
-              dialyzer,
-              lint,
-              lint_version,
-              audit_deps
-            ]
-          filters: *master_and_version_branches_and_all_tags
+      # - build:
+      #     filters: &all_branches_and_tags
+      #       branches:
+      #         only: /.+/
+      #       tags:
+      #         only: /.+/
+      # - test_barebone_release:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - notify_services:
+      #     requires: [deploy_watcher, deploy_watcher_info, deploy_child_chain]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - coveralls_report:
+      #     requires:
+      #       - child_chain_coveralls_and_integration_tests
+      #       - watcher_coveralls_and_integration_tests
+      #       - watcher_info_coveralls_and_integration_tests
+      #       - common_coveralls_and_integration_tests
+      #       - test
+      # - child_chain_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - watcher_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - watcher_info_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - common_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - test_docker_compose_release:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - test_docker_compose_reorg:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - audit_deps:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - lint:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - lint_version:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - sobelow:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - dialyzer:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - test:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - property_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # # Publish in case of master branch, version branches and version tags.
+      # - publish_child_chain:
+      #     requires:
+      #       [
+      #         child_chain_coveralls_and_integration_tests,
+      #         watcher_coveralls_and_integration_tests,
+      #         watcher_info_coveralls_and_integration_tests,
+      #         common_coveralls_and_integration_tests,
+      #         test,
+      #         property_tests,
+      #         dialyzer,
+      #         lint,
+      #         lint_version,
+      #         audit_deps
+      #       ]
+      #     filters: &master_and_version_branches_and_all_tags
+      #       branches:
+      #         only:
+      #           - master
+      #           # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+      #           - /^v[0-9]+\.[0-9]+/
+      #       tags:
+      #         only:
+      #           - /.+/
+      # - publish_watcher:
+      #     requires:
+      #       [
+      #         child_chain_coveralls_and_integration_tests,
+      #         watcher_coveralls_and_integration_tests,
+      #         watcher_info_coveralls_and_integration_tests,
+      #         common_coveralls_and_integration_tests,
+      #         test,
+      #         property_tests,
+      #         dialyzer,
+      #         lint,
+      #         lint_version,
+      #         audit_deps
+      #       ]
+      #     filters: *master_and_version_branches_and_all_tags
+      # - publish_watcher_info:
+      #     requires:
+      #       [
+      #         child_chain_coveralls_and_integration_tests,
+      #         watcher_coveralls_and_integration_tests,
+      #         watcher_info_coveralls_and_integration_tests,
+      #         common_coveralls_and_integration_tests,
+      #         test,
+      #         property_tests,
+      #         dialyzer,
+      #         lint,
+      #         lint_version,
+      #         audit_deps
+      #       ]
+      #     filters: *master_and_version_branches_and_all_tags
+      - increase_chart_version_childchain:
+        # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+        filters: *master_and_version_branches_and_all_tags
       # Release deploy to development in case of master branch.
-      - deploy_child_chain:
-          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-          filters:
-            branches:
-              only:
-                - master
-      - deploy_watcher:
-          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-          filters:
-            branches:
-              only:
-                - master
-      - deploy_watcher_info:
-          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-          filters:
-            branches:
-              only:
-                - master
+      # - deploy_child_chain:
+      #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - deploy_watcher:
+      #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - deploy_watcher_info:
+      #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -768,13 +768,12 @@ jobs:
       - run: IMAGE_NAME=$WATCHER_INFO_IMAGE_NAME sh .circleci/ci_publish.sh
 
   increase_chart_version_childchain:
-    machine:
-      # image: cimg/base:2020.01
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/base:2020.01
+      # image: ubuntu-1604:201903-01
     environment:
       CHART_NAME: childchain
-      HELM_CHART_REPO: helm-development
-      # GITHUB_API_TOKEN: ${HOUSE_KEEPER_BOT_TOKEN}
+      HELM_CHART_REPO: helm-development-boolafish-playground
     steps:
       - checkout
       - run: sh .circleci/ci_increase_chart_version.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,7 +772,7 @@ jobs:
       - image: cimg/base:2020.01
     environment:
       CHART_NAME: childchain
-      HELM_CHART_REPO: helm-development-boolafish-playground
+      HELM_CHART_REPO: helm-development
     steps:
       - checkout
       - run: sh .circleci/ci_increase_chart_version.sh
@@ -782,7 +782,7 @@ jobs:
       - image: cimg/base:2020.01
     environment:
       CHART_NAME: watcher
-      HELM_CHART_REPO: helm-development-boolafish-playground
+      HELM_CHART_REPO: helm-development
     steps:
       - checkout
       - run: sh .circleci/ci_increase_chart_version.sh
@@ -792,7 +792,7 @@ jobs:
       - image: cimg/base:2020.01
     environment:
       CHART_NAME: watcher-info
-      HELM_CHART_REPO: helm-development-boolafish-playground
+      HELM_CHART_REPO: helm-development
     steps:
       - checkout
       - run: sh .circleci/ci_increase_chart_version.sh
@@ -883,152 +883,154 @@ workflows:
           requires: [build]
   build-test-deploy:
     jobs:
-      # - build:
-      #     filters: &all_branches_and_tags
-      #       branches:
-      #         only: /.+/
-      #       tags:
-      #         only: /.+/
-      # - test_barebone_release:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - notify_services:
-      #     requires: [deploy_watcher, deploy_watcher_info, deploy_child_chain]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - coveralls_report:
-      #     requires:
-      #       - child_chain_coveralls_and_integration_tests
-      #       - watcher_coveralls_and_integration_tests
-      #       - watcher_info_coveralls_and_integration_tests
-      #       - common_coveralls_and_integration_tests
-      #       - test
-      # - child_chain_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - watcher_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - watcher_info_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - common_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - test_docker_compose_release:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - test_docker_compose_reorg:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - audit_deps:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - lint:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - lint_version:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - sobelow:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - dialyzer:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - test:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - property_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # # Publish in case of master branch, version branches and version tags.
-      # - publish_child_chain:
-      #     requires:
-      #       [
-      #         child_chain_coveralls_and_integration_tests,
-      #         watcher_coveralls_and_integration_tests,
-      #         watcher_info_coveralls_and_integration_tests,
-      #         common_coveralls_and_integration_tests,
-      #         test,
-      #         property_tests,
-      #         dialyzer,
-      #         lint,
-      #         lint_version,
-      #         audit_deps
-      #       ]
-      #     filters: &master_and_version_branches_and_all_tags
-      #       branches:
-      #         only:
-      #           - master
-      #           # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-      #           - /^v[0-9]+\.[0-9]+/
-      #       tags:
-      #         only:
-      #           - /.+/
-      # - publish_watcher:
-      #     requires:
-      #       [
-      #         child_chain_coveralls_and_integration_tests,
-      #         watcher_coveralls_and_integration_tests,
-      #         watcher_info_coveralls_and_integration_tests,
-      #         common_coveralls_and_integration_tests,
-      #         test,
-      #         property_tests,
-      #         dialyzer,
-      #         lint,
-      #         lint_version,
-      #         audit_deps
-      #       ]
-      #     filters: *master_and_version_branches_and_all_tags
-      # - publish_watcher_info:
-      #     requires:
-      #       [
-      #         child_chain_coveralls_and_integration_tests,
-      #         watcher_coveralls_and_integration_tests,
-      #         watcher_info_coveralls_and_integration_tests,
-      #         common_coveralls_and_integration_tests,
-      #         test,
-      #         property_tests,
-      #         dialyzer,
-      #         lint,
-      #         lint_version,
-      #         audit_deps
-      #       ]
-      #     filters: *master_and_version_branches_and_all_tags
+      - build:
+          filters: &all_branches_and_tags
+            branches:
+              only: /.+/
+            tags:
+              only: /.+/
+      - test_barebone_release:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - notify_services:
+          requires: [deploy_watcher, deploy_watcher_info, deploy_child_chain]
+          filters:
+            branches:
+              only:
+                - master
+      - coveralls_report:
+          requires:
+            - child_chain_coveralls_and_integration_tests
+            - watcher_coveralls_and_integration_tests
+            - watcher_info_coveralls_and_integration_tests
+            - common_coveralls_and_integration_tests
+            - test
+      - child_chain_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - watcher_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - watcher_info_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - common_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - test_docker_compose_release:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - test_docker_compose_reorg:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - audit_deps:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - lint:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - lint_version:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - sobelow:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - dialyzer:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - test:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - property_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      # Publish in case of master branch, version branches and version tags.
+      - publish_child_chain:
+          requires:
+            [
+              child_chain_coveralls_and_integration_tests,
+              watcher_coveralls_and_integration_tests,
+              watcher_info_coveralls_and_integration_tests,
+              common_coveralls_and_integration_tests,
+              test,
+              property_tests,
+              dialyzer,
+              lint,
+              lint_version,
+              audit_deps
+            ]
+          filters: &master_and_version_branches_and_all_tags
+            branches:
+              only:
+                - master
+                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+                - /^v[0-9]+\.[0-9]+/
+            tags:
+              only:
+                - /.+/
+      - publish_watcher:
+          requires:
+            [
+              child_chain_coveralls_and_integration_tests,
+              watcher_coveralls_and_integration_tests,
+              watcher_info_coveralls_and_integration_tests,
+              common_coveralls_and_integration_tests,
+              test,
+              property_tests,
+              dialyzer,
+              lint,
+              lint_version,
+              audit_deps
+            ]
+          filters: *master_and_version_branches_and_all_tags
+      - publish_watcher_info:
+          requires:
+            [
+              child_chain_coveralls_and_integration_tests,
+              watcher_coveralls_and_integration_tests,
+              watcher_info_coveralls_and_integration_tests,
+              common_coveralls_and_integration_tests,
+              test,
+              property_tests,
+              dialyzer,
+              lint,
+              lint_version,
+              audit_deps
+            ]
+          filters: *master_and_version_branches_and_all_tags
+      # Release deploy to development in case of master branch.
+      - deploy_child_chain:
+          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          filters:
+            branches:
+              only:
+                - master
+      - deploy_watcher:
+          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          filters:
+            branches:
+              only:
+                - master
+      - deploy_watcher_info:
+          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          filters:
+            branches:
+              only:
+                - master
+      # Increase chart version for new release
       - increase_chart_version_childchain:
-        # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
           filters: &only_release_tag
             branches:
               ignore: /.*/
             tags:
               only:
+                # eg. v1.0.3-pre.0, v1.0.3, ...
                 - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - increase_chart_version_watcher:
-        # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
           filters: *only_release_tag
 
       - increase_chart_version_watcher_info:
-        # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
+          requires: [publish_child_chain, publish_watcher, publish_watcher_info]
           filters: *only_release_tag
-      # Release deploy to development in case of master branch.
-      # - deploy_child_chain:
-      #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - deploy_watcher:
-      #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - deploy_watcher_info:
-      #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1030,7 +1030,6 @@ workflows:
       - increase_chart_version_watcher:
           requires: [publish_child_chain, publish_watcher, publish_watcher_info]
           filters: *only_release_tag
-
       - increase_chart_version_watcher_info:
           requires: [publish_child_chain, publish_watcher, publish_watcher_info]
           filters: *only_release_tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -982,7 +982,12 @@ workflows:
       #     filters: *master_and_version_branches_and_all_tags
       - increase_chart_version_childchain:
         # requires: [publish_child_chain, publish_watcher, publish_watcher_info]
-        filters: *master_and_version_branches_and_all_tags
+          filters: &only_release_tag
+            branches:
+              ignore: /.*/
+            tags:
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       # Release deploy to development in case of master branch.
       # - deploy_child_chain:
       #     requires: [publish_child_chain, publish_watcher, publish_watcher_info]


### PR DESCRIPTION
:clipboard: https://github.com/omgnetwork/releases/issues/23

## Overview

Provide a CircleCI job that will trigger auto chart version increase PR after docker images are published successfully.

## Changes

- Add a script to trigger Github action on helm-development repo
- Hook the script to CircleCI job with release tag filter
- [outside the PR] Have set `GITHUB_API_TOKEN` in circle ci env var manually

## Testing

Done via playground repo and commenting out other jobs (so test the hook only). Here are the testing releases in the playground repo: https://github.com/omgnetwork/elixir-omg-boolafish-playground/releases


- example version bumping jobs: [here](https://app.circleci.com/pipelines/github/omgnetwork/elixir-omg-boolafish-playground/34/workflows/fc8f82a3-a514-4b77-9659-cbb46b2a0b39)
- example result auto version bumping PR: [here](https://github.com/omgnetwork/helm-development-boolafish-playground/pull/16)

