### PR TITLE
Verity: trigger block submit when enough pending txs

### DIFF
--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -138,7 +138,7 @@ defmodule OMG.State do
   The beginning of the block is `true/false` depending on whether there have been no transactions executed yet for
   the current child chain block
   """
-  @spec get_status() :: {non_neg_integer(), boolean()}
+  @spec get_status() :: {non_neg_integer(), boolean(), non_neg_integer()}
   def get_status() do
     GenServer.call(__MODULE__, :get_status, @timeout)
   end

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -384,6 +384,7 @@ defmodule OMG.State.Core do
     UtxoSet.exists?(utxos, utxo_pos)
   end
 
+  # TODO: check if we need `is_block_beggining` at all
   @doc """
       Gets the current block's height and whether at the beginning of the block
   """

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -387,10 +387,12 @@ defmodule OMG.State.Core do
   @doc """
       Gets the current block's height and whether at the beginning of the block
   """
-  @spec get_status(t()) :: {current_block_height :: non_neg_integer(), is_block_beginning :: boolean()}
+  @spec get_status(t()) ::
+          {current_block_height :: non_neg_integer(), is_block_beginning :: boolean(),
+           transaction_count :: non_neg_integer()}
   def get_status(%__MODULE__{height: height, tx_index: tx_index, pending_txs: pending}) do
     is_beginning = tx_index == 0 && Enum.empty?(pending)
-    {height, is_beginning}
+    {height, is_beginning, tx_index}
   end
 
   defp add_pending_tx(%Core{pending_txs: pending_txs, tx_index: tx_index} = state, %Transaction.Recovered{} = new_tx) do

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -384,7 +384,6 @@ defmodule OMG.State.Core do
     UtxoSet.exists?(utxos, utxo_pos)
   end
 
-  # TODO: check if we need `is_block_beggining` at all
   @doc """
       Gets the current block's height and whether at the beginning of the block
   """

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -511,7 +511,7 @@ defmodule OMG.State.CoreTest do
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "can't spend own output", %{bob: bob, state_alice_deposit: state} do
     # The transaction here is designed so that it would spend its own output. Sanity checking first
-    {1000, true} = Core.get_status(state)
+    {1000, true, 0} = Core.get_status(state)
     recovered2 = create_recovered([{1000, 0, 0, bob}], @eth, [{bob, 6}])
 
     state
@@ -803,20 +803,20 @@ defmodule OMG.State.CoreTest do
 
   @tag fixtures: [:state_empty]
   test "Getting current block height on empty state", %{state_empty: state} do
-    assert {@blknum1, _} = Core.get_status(state)
+    assert {@blknum1, _, _} = Core.get_status(state)
   end
 
   @tag fixtures: [:state_empty]
   test "Getting current block height with one formed block", %{state_empty: state} do
     {:ok, {_, _}, new_state} = form_block_check(state)
-    assert {@blknum2, true} = Core.get_status(new_state)
+    assert {@blknum2, true, 0} = Core.get_status(new_state)
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "beginning of block changes when transactions executed and block formed",
        %{alice: alice, state_empty: state} do
     # at empty state it is at the beginning of the next block
-    assert {@blknum1, true} = Core.get_status(state)
+    assert {@blknum1, true, 0} = Core.get_status(state)
 
     # when we execute a tx it isn't at the beginning
     {:ok, _, state} =
@@ -824,12 +824,12 @@ defmodule OMG.State.CoreTest do
       |> do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
       |> Core.exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 9}]), @fee)
 
-    assert {@blknum1, false} = Core.get_status(state)
+    assert {@blknum1, false, 1} = Core.get_status(state)
 
     # when a block has been newly formed it is at the beginning
     {:ok, _, state} = form_block_check(state)
 
-    assert {@blknum2, true} = Core.get_status(state)
+    assert {@blknum2, true, 0} = Core.get_status(state)
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]

--- a/apps/omg/test/omg/state_test.exs
+++ b/apps/omg/test/omg/state_test.exs
@@ -74,7 +74,7 @@ defmodule OMG.StateTest do
     assert {:ok, _} = State.exec(TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 9}]), fee)
 
     # block forming & status
-    assert {blknum, _} = State.get_status()
+    assert {blknum, _, _} = State.get_status()
     assert :ok = State.form_block()
     # exits, with invalid ones
     assert {:ok, _db, _} = State.exit_utxos([Utxo.position(blknum, 0, 0)])

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -104,7 +104,7 @@ defmodule OMG.ChildChain.BlockQueue do
     _ = Logger.info("Starting BlockQueue, top_mined_hash: #{inspect(Encoding.to_hex(top_mined_hash))}")
 
     block_submit_every_nth = Keyword.fetch!(args, :block_submit_every_nth)
-    block_submit_when_n_txs = Keyword.fetch!(args, :block_submit_when_n_txs)
+    block_submit_after_n_txs = Keyword.fetch!(args, :block_submit_after_n_txs)
     block_submit_max_gas_price = Keyword.fetch!(args, :block_submit_max_gas_price)
     gas_price_adj_params = %GasPriceAdjustment{max_gas_price: block_submit_max_gas_price}
 
@@ -116,7 +116,7 @@ defmodule OMG.ChildChain.BlockQueue do
         parent_height: parent_height,
         child_block_interval: child_block_interval,
         block_submit_every_nth: block_submit_every_nth,
-        block_submit_when_n_txs: block_submit_when_n_txs,
+        block_submit_after_n_txs: block_submit_after_n_txs,
         finality_threshold: finality_threshold,
         gas_price_adj_params: gas_price_adj_params
       )
@@ -142,7 +142,7 @@ defmodule OMG.ChildChain.BlockQueue do
     {:ok, _} = :timer.send_interval(interval, self(), :check_ethereum_status)
 
     _ =
-      if is_number(block_submit_when_n_txs) do
+      if is_number(block_submit_after_n_txs) do
         block_fulfillment_check_interval_ms = Keyword.fetch!(args, :block_fulfillment_check_interval_ms)
         {:ok, _} = :timer.send_interval(block_fulfillment_check_interval_ms, self(), :check_block_fulfillment)
       end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -141,10 +141,11 @@ defmodule OMG.ChildChain.BlockQueue do
     interval = Keyword.fetch!(args, :block_queue_eth_height_check_interval_ms)
     {:ok, _} = :timer.send_interval(interval, self(), :check_ethereum_status)
 
-    if is_number(block_submit_when_n_txs) do
-      block_fulfillment_check_interval_ms = Keyword.fetch!(args, :block_fulfillment_check_interval_ms)
-      {:ok, _} = :timer.send_interval(block_fulfillment_check_interval_ms, self(), :check_block_fulfillment)
-    end
+    _ =
+      if is_number(block_submit_when_n_txs) do
+        block_fulfillment_check_interval_ms = Keyword.fetch!(args, :block_fulfillment_check_interval_ms)
+        {:ok, _} = :timer.send_interval(block_fulfillment_check_interval_ms, self(), :check_block_fulfillment)
+      end
 
     # `link: true` because we want the `BlockQueue` to restart and resubscribe, if the bus crashes
     :ok = OMG.Bus.subscribe({:child_chain, "blocks"}, link: true)

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -142,8 +142,8 @@ defmodule OMG.ChildChain.BlockQueue do
     {:ok, _} = :timer.send_interval(interval, self(), :check_ethereum_status)
 
     if is_number(block_submit_when_n_txs) do
-      block_fulfilment_check_interval_ms = Keyword.fetch!(args, :block_fulfilment_check_interval_ms)
-      {:ok, _} = :timer.send_interval(block_fulfilment_check_interval_ms, self(), :check_block_fulfilment)
+      block_fulfillment_check_interval_ms = Keyword.fetch!(args, :block_fulfillment_check_interval_ms)
+      {:ok, _} = :timer.send_interval(block_fulfillment_check_interval_ms, self(), :check_block_fulfillment)
     end
 
     # `link: true` because we want the `BlockQueue` to restart and resubscribe, if the bus crashes
@@ -193,11 +193,11 @@ defmodule OMG.ChildChain.BlockQueue do
 
   `OMG.ChildChain.BlockQueue.Core` decides whether a new block should be formed or not.
   """
-  def handle_info(:check_block_fulfilment, state) do
+  def handle_info(:check_block_fulfillment, state) do
     {_, _, txs_count} = OMG.State.get_status()
 
     state1 =
-      case Core.check_block_fulfiled_enough(state, txs_count) do
+      case Core.check_block_fulfilled(state, txs_count) do
         {:do_form_block, state1} ->
           :ok = OMG.State.form_block()
           state1

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -107,7 +107,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
     # config:
     child_block_interval: nil,
     block_submit_every_nth: 1,
-    block_submit_when_n_txs: :infinity,
+    block_submit_after_n_txs: :infinity,
     finality_threshold: 12,
     gas_price_adj_params: %GasPriceAdjustment{}
   ]
@@ -132,7 +132,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
           block_submit_every_nth: pos_integer(),
           # configure to trigger forming a child chain block when there are this many pending transactions.
           # Defaults to `:infinity` which means - pending transaction count takes no effect on block forming.
-          block_submit_when_n_txs: pos_integer() | atom(),
+          block_submit_after_n_txs: pos_integer() | atom(),
           # depth of max reorg we take into account
           finality_threshold: pos_integer(),
           # the gas price adjustment strategy parameters
@@ -532,7 +532,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
            parent_height: parent_height,
            last_enqueued_block_at_height: last_enqueued_block_at_height,
            block_submit_every_nth: block_submit_every_nth,
-           block_submit_when_n_txs: block_submit_when_n_txs,
+           block_submit_after_n_txs: block_submit_after_n_txs,
            wait_for_enqueue: wait_for_enqueue
          },
          pending_txs_count
@@ -540,7 +540,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
     # e.g. if we're at 15th Ethereum block now, last enqueued was at 14th, we're submitting a child chain block on every
     # single Ethereum block (`block_submit_every_nth` == 1), then we could form a new block (`it_is_time` is `true`)
     it_is_time = parent_height - last_enqueued_block_at_height >= block_submit_every_nth
-    block_fulfilled = pending_txs_count >= block_submit_when_n_txs
+    block_fulfilled = pending_txs_count >= block_submit_after_n_txs
     is_empty_block = pending_txs_count == 0
     should_form_block = (it_is_time or block_fulfilled) and !wait_for_enqueue and !is_empty_block
 

--- a/apps/omg_child_chain/lib/omg_child_chain/configuration.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/configuration.ex
@@ -48,9 +48,9 @@ defmodule OMG.ChildChain.Configuration do
     Application.fetch_env!(@app, :block_submit_max_gas_price)
   end
 
-  @spec block_fulfilment_check_interval_ms() :: no_return | pos_integer()
-  def block_fulfilment_check_interval_ms() do
-    Application.fetch_env!(@app, :block_fulfilment_check_interval_ms)
+  @spec block_fulfillment_check_interval_ms() :: no_return | pos_integer()
+  def block_fulfillment_check_interval_ms() do
+    Application.fetch_env!(@app, :block_fulfillment_check_interval_ms)
   end
 
   @doc """

--- a/apps/omg_child_chain/lib/omg_child_chain/configuration.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/configuration.ex
@@ -38,9 +38,19 @@ defmodule OMG.ChildChain.Configuration do
     Application.fetch_env!(@app, :block_submit_every_nth)
   end
 
+  @spec block_submit_when_n_txs() :: no_return | pos_integer()
+  def block_submit_when_n_txs() do
+    Application.fetch_env!(@app, :block_submit_when_n_txs)
+  end
+
   @spec block_submit_max_gas_price() :: no_return | pos_integer()
   def block_submit_max_gas_price() do
     Application.fetch_env!(@app, :block_submit_max_gas_price)
+  end
+
+  @spec block_fulfilment_check_interval_ms() :: no_return | pos_integer()
+  def block_fulfilment_check_interval_ms() do
+    Application.fetch_env!(@app, :block_fulfilment_check_interval_ms)
   end
 
   @doc """

--- a/apps/omg_child_chain/lib/omg_child_chain/configuration.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/configuration.ex
@@ -38,9 +38,9 @@ defmodule OMG.ChildChain.Configuration do
     Application.fetch_env!(@app, :block_submit_every_nth)
   end
 
-  @spec block_submit_when_n_txs() :: no_return | pos_integer()
-  def block_submit_when_n_txs() do
-    Application.fetch_env!(@app, :block_submit_when_n_txs)
+  @spec block_submit_after_n_txs() :: no_return | pos_integer()
+  def block_submit_after_n_txs() do
+    Application.fetch_env!(@app, :block_submit_after_n_txs)
   end
 
   @spec block_submit_max_gas_price() :: no_return | pos_integer()

--- a/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
@@ -66,7 +66,7 @@ defmodule OMG.ChildChain.SyncSupervisor do
     block_submit_when_n_txs = Configuration.block_submit_when_n_txs()
     block_submit_max_gas_price = Configuration.block_submit_max_gas_price()
     ethereum_events_check_interval_ms = OMG.Configuration.ethereum_events_check_interval_ms()
-    block_fulfilment_check_interval_ms = Configuration.block_fulfilment_check_interval_ms()
+    block_fulfillment_check_interval_ms = Configuration.block_fulfillment_check_interval_ms()
     coordinator_eth_height_check_interval_ms = OMG.Configuration.coordinator_eth_height_check_interval_ms()
     deposit_finality_margin = OMG.Configuration.deposit_finality_margin()
     child_block_interval = OMG.Eth.Configuration.child_block_interval()
@@ -81,7 +81,7 @@ defmodule OMG.ChildChain.SyncSupervisor do
          contract_deployment_height: contract_deployment_height,
          metrics_collection_interval: metrics_collection_interval,
          block_queue_eth_height_check_interval_ms: block_queue_eth_height_check_interval_ms,
-         block_fulfilment_check_interval_ms: block_fulfilment_check_interval_ms,
+         block_fulfillment_check_interval_ms: block_fulfillment_check_interval_ms,
          submission_finality_margin: submission_finality_margin,
          block_submit_every_nth: block_submit_every_nth,
          block_submit_when_n_txs: block_submit_when_n_txs,

--- a/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
@@ -63,7 +63,7 @@ defmodule OMG.ChildChain.SyncSupervisor do
     block_queue_eth_height_check_interval_ms = Configuration.block_queue_eth_height_check_interval_ms()
     submission_finality_margin = Configuration.submission_finality_margin()
     block_submit_every_nth = Configuration.block_submit_every_nth()
-    block_submit_when_n_txs = Configuration.block_submit_when_n_txs()
+    block_submit_after_n_txs = Configuration.block_submit_after_n_txs()
     block_submit_max_gas_price = Configuration.block_submit_max_gas_price()
     ethereum_events_check_interval_ms = OMG.Configuration.ethereum_events_check_interval_ms()
     block_fulfillment_check_interval_ms = Configuration.block_fulfillment_check_interval_ms()
@@ -84,7 +84,7 @@ defmodule OMG.ChildChain.SyncSupervisor do
          block_fulfillment_check_interval_ms: block_fulfillment_check_interval_ms,
          submission_finality_margin: submission_finality_margin,
          block_submit_every_nth: block_submit_every_nth,
-         block_submit_when_n_txs: block_submit_when_n_txs,
+         block_submit_after_n_txs: block_submit_after_n_txs,
          block_submit_max_gas_price: block_submit_max_gas_price,
          child_block_interval: child_block_interval
        ]},

--- a/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
@@ -63,8 +63,10 @@ defmodule OMG.ChildChain.SyncSupervisor do
     block_queue_eth_height_check_interval_ms = Configuration.block_queue_eth_height_check_interval_ms()
     submission_finality_margin = Configuration.submission_finality_margin()
     block_submit_every_nth = Configuration.block_submit_every_nth()
+    block_submit_when_n_txs = Configuration.block_submit_when_n_txs()
     block_submit_max_gas_price = Configuration.block_submit_max_gas_price()
     ethereum_events_check_interval_ms = OMG.Configuration.ethereum_events_check_interval_ms()
+    block_fulfilment_check_interval_ms = Configuration.block_fulfilment_check_interval_ms()
     coordinator_eth_height_check_interval_ms = OMG.Configuration.coordinator_eth_height_check_interval_ms()
     deposit_finality_margin = OMG.Configuration.deposit_finality_margin()
     child_block_interval = OMG.Eth.Configuration.child_block_interval()
@@ -79,8 +81,10 @@ defmodule OMG.ChildChain.SyncSupervisor do
          contract_deployment_height: contract_deployment_height,
          metrics_collection_interval: metrics_collection_interval,
          block_queue_eth_height_check_interval_ms: block_queue_eth_height_check_interval_ms,
+         block_fulfilment_check_interval_ms: block_fulfilment_check_interval_ms,
          submission_finality_margin: submission_finality_margin,
          block_submit_every_nth: block_submit_every_nth,
+         block_submit_when_n_txs: block_submit_when_n_txs,
          block_submit_max_gas_price: block_submit_max_gas_price,
          child_block_interval: child_block_interval
        ]},

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -378,7 +378,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "transaction count below the threshold does not form block", %{empty: empty} do
       assert {:dont_form_block, _} =
                empty
-               |> Map.put(:block_submit_when_n_txs, 100)
+               |> Map.put(:block_submit_after_n_txs, 100)
                |> Core.enqueue_block("1", 1000, 1)
                |> Core.check_block_fulfilled(99)
     end
@@ -386,7 +386,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "transaction count at threshold triggers block formation", %{empty: empty} do
       queue =
         empty
-        |> Map.put(:block_submit_when_n_txs, 100)
+        |> Map.put(:block_submit_after_n_txs, 100)
         |> Core.enqueue_block("1", 1000, 1)
 
       assert {:do_form_block, _} = Core.check_block_fulfilled(queue, 100)
@@ -396,7 +396,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "transaction count does not interfere with ethereum height", %{empty: empty} do
       queue =
         empty
-        |> Map.put(:block_submit_when_n_txs, 100)
+        |> Map.put(:block_submit_after_n_txs, 100)
         |> Core.enqueue_block("1", 1000, 1)
 
       assert {:dont_form_block, _} =
@@ -412,7 +412,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "does not form block when previous submission is awaiting", %{empty: empty} do
       queue =
         empty
-        |> Map.put(:block_submit_when_n_txs, 100)
+        |> Map.put(:block_submit_after_n_txs, 100)
         |> Core.enqueue_block("1", 1000, 0)
         |> Map.put(:wait_for_enqueue, true)
 

--- a/apps/omg_watcher/lib/omg_watcher/api/status_cache/external.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/status_cache/external.ex
@@ -94,7 +94,7 @@ defmodule OMG.Watcher.API.StatusCache.External do
 
   defp get_validated_child_block_number() do
     child_block_interval = Configuration.child_block_interval()
-    {state_current_block, _} = State.get_status()
+    {state_current_block, _, _} = State.get_status()
     state_current_block - child_block_interval
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -84,7 +84,7 @@ defmodule OMG.Watcher.BlockGetter do
     exit_processor_initial_results = ExitProcessor.check_validity(10 * 60_000)
     # State treats current as the next block to be executed or a block that is being executed
     # while top block number is a block that has been formed (they differ by the interval)
-    {current_block_height, state_at_block_beginning} = State.get_status()
+    {current_block_height, state_at_block_beginning, _} = State.get_status()
     child_top_block_number = current_block_height - child_block_interval
 
     {:ok, last_synced_height} = OMG.DB.get_single_value(:last_block_getter_eth_height)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -649,7 +649,7 @@ defmodule OMG.Watcher.ExitProcessor do
 
   defp run_status_gets(%ExitProcessor.Request{eth_height_now: nil, blknum_now: nil} = request) do
     {:ok, eth_height_now} = EthereumHeight.get()
-    {blknum_now, _} = State.get_status()
+    {blknum_now, _, _} = State.get_status()
 
     _ = Logger.debug("eth_height_now: #{inspect(eth_height_now)}, blknum_now: #{inspect(blknum_now)}")
     %{request | eth_height_now: eth_height_now, blknum_now: blknum_now}

--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,8 @@ config :omg_child_chain,
   metrics_collection_interval: 60_000,
   fee_adapter_check_interval_ms: 10_000,
   fee_buffer_duration_ms: 30_000,
-  fee_adapter: {OMG.ChildChain.Fees.FileAdapter, opts: [specs_file_path: nil]}
+  fee_adapter: {OMG.ChildChain.Fees.FileAdapter, opts: [specs_file_path: nil]},
+  block_fulfilment_check_interval_ms: 2_000
 
 config :omg_child_chain, OMG.ChildChain.Tracer,
   service: :omg_child_chain,

--- a/config/config.exs
+++ b/config/config.exs
@@ -51,7 +51,7 @@ config :omg_child_chain,
   fee_adapter_check_interval_ms: 10_000,
   fee_buffer_duration_ms: 30_000,
   fee_adapter: {OMG.ChildChain.Fees.FileAdapter, opts: [specs_file_path: nil]},
-  block_fulfilment_check_interval_ms: 2_000
+  block_fulfillment_check_interval_ms: 2_000
 
 config :omg_child_chain, OMG.ChildChain.Tracer,
   service: :omg_child_chain,


### PR DESCRIPTION
# ⚠️ <span style="color: red">This is investigative work only and is not going to be merged into master</span>

Fixes https://github.com/omgnetwork/private-issues/issues/77

## Overview

Allows to shorten the time for next block submission (which is not based on mined Ethereum blocks count) when there is enough pending transaction collected already.
Pending transaction count which triggers blocks submission can be configured by `BLOCK_SUBMIT_WHEN_N_TXS` environment variable.
When not set it defaults to _infinity_ which effectively switch off the feature.

## Changes

Added 2 more Childchain's configuration properties and pass them down to the `BlockQueue` module.
- submit_block_when_n_txs
- block_fulfillment_check_interval_ms


When `submit_block_when_n_txs` is set to a number it will set a timer checking pending transactions count in the interval of `submit_block_when_n_txs` milliseconds. Timer will trigger block forming and submission to the rootchain according to the transactions count in the block and `submit_block_when_n_txs` property.

- ...

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
