### PR TITLE
fix: recheck PR label on synchronize and reopen

### DIFF
--- a/.github/workflows/enforce-changelog-labels.yml
+++ b/.github/workflows/enforce-changelog-labels.yml
@@ -16,7 +16,6 @@ jobs:
         id: check-changelog-label
         run: |
           set -o xtrace
-
           # Using the issues API instead of pulls because it can return only the labels
           curl "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/labels" \
           | grep -o '"name": "[^"]*' \

--- a/.github/workflows/enforce-changelog-labels.yml
+++ b/.github/workflows/enforce-changelog-labels.yml
@@ -2,7 +2,7 @@ name: Enforce changelog labels
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled]
+    types: [opened, labeled, unlabeled, synchronize, reopened]
     branches: [master]
 
 jobs:

--- a/docker-compose.feefeed.yml
+++ b/docker-compose.feefeed.yml
@@ -9,7 +9,7 @@ services:
         condition: service_healthy
 
   feefeed:
-    image: "omisego/feefeed:latest"
+    image: "omisego/feefeed-dev:04c8e5a"
     command: "start"
     container_name: feefeed
     environment:

--- a/docker-compose.feefeed.yml
+++ b/docker-compose.feefeed.yml
@@ -9,7 +9,7 @@ services:
         condition: service_healthy
 
   feefeed:
-    image: "omisego/feefeed-dev:04c8e5a"
+    image: "omisego/feefeed:latest"
     command: "start"
     container_name: feefeed
     environment:


### PR DESCRIPTION
## Overview

Fixes the issue where the label checker blocks the build from passing because all the build statuses are reset on a PR push and the label checker didn't get re-triggered.

## Changes

- Enable PR label check on PR synchronize and reopen.

## Testing

1. Create a PR
2. Label the PR with a supported label, e.g. `chore`
3. The `enforce-changelog-label` job should run and pass
4. Push a new commit to the PR
5. The `enforce-changelog-label` job should rerun and pass