### PR TITLE
Publish the perf project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1111,15 +1111,16 @@ workflows:
           filters: *master_and_version_branches_and_all_tags
 
       - publish_perf:
-          filters: *all_branches_and_tags
-          #   branches:
-          #     only:
-          #       - master
-          #       # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-          #       - /^v[0-9]+\.[0-9]+/
-          #   tags:
-          #     only:
-          #       - /.+/
+          requires: [test_docker_compose_performance]
+          filters:
+            branches:
+              only:
+                - master
+                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+                - /^v[0-9]+\.[0-9]+/
+            tags:
+              only:
+                - /.+/
       # Increase chart version for master, this will end up trigger deployment on dev
       - increase_chart_version_watcher_master:
           requires: [publish_watcher, publish_watcher_info]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,15 +1109,17 @@ workflows:
               audit_deps
             ]
           filters: *master_and_version_branches_and_all_tags
+
       - publish_perf:
-          branches:
-            only:
-              - master
-              # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-              - /^v[0-9]+\.[0-9]+/
-          tags:
-            only:
-              - /.+/
+          filters:
+            branches:
+              only:
+                - master
+                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+                - /^v[0-9]+\.[0-9]+/
+            tags:
+              only:
+                - /.+/
       # Increase chart version for master, this will end up trigger deployment on dev
       - increase_chart_version_watcher_master:
           requires: [publish_watcher, publish_watcher_info]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -870,6 +870,16 @@ jobs:
           path: current_release/
       - run: IMAGE_NAME=$WATCHER_IMAGE_NAME sh .circleci/ci_publish.sh
 
+  publish_perf:
+    machine:
+      image: ubuntu-1604:201903-01
+    environment:
+      PERF_IMAGE_NAME: "omisego/perf"
+    steps:
+      - checkout
+      - run: cd priv/perf && make docker IMAGE_NAME=$PERF_IMAGE_NAME
+      - run: IMAGE_NAME=$PERF_IMAGE_NAME sh .circleci/ci_publish.sh
+
   publish_watcher_info:
     machine:
       image: ubuntu-1604:201903-01
@@ -1099,6 +1109,15 @@ workflows:
               audit_deps
             ]
           filters: *master_and_version_branches_and_all_tags
+      - publish_perf:
+          branches:
+            only:
+              - master
+              # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+              - /^v[0-9]+\.[0-9]+/
+          tags:
+            only:
+              - /.+/
       # Increase chart version for master, this will end up trigger deployment on dev
       - increase_chart_version_watcher_master:
           requires: [publish_watcher, publish_watcher_info]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1111,16 +1111,15 @@ workflows:
           filters: *master_and_version_branches_and_all_tags
 
       - publish_perf:
-          filters: *all_branches_and_tags
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
-          #       # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-          #       - /^v[0-9]+\.[0-9]+/
-          #   tags:
-          #     only:
-          #       - /.+/
+          filters:
+            branches:
+              only:
+                - master
+                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+                - /^v[0-9]+\.[0-9]+/
+            tags:
+              only:
+                - /.+/
       # Increase chart version for master, this will end up trigger deployment on dev
       - increase_chart_version_watcher_master:
           requires: [publish_watcher, publish_watcher_info]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,7 +877,7 @@ jobs:
       PERF_IMAGE_NAME: "omisego/perf"
     steps:
       - checkout
-      - run: cd priv/perf && make docker IMAGE_NAME=$PERF_IMAGE_NAME
+      - run: make docker-perf IMAGE_NAME=$PERF_IMAGE_NAME
       - run: IMAGE_NAME=$PERF_IMAGE_NAME sh .circleci/ci_publish.sh
 
   publish_watcher_info:
@@ -1111,15 +1111,15 @@ workflows:
           filters: *master_and_version_branches_and_all_tags
 
       - publish_perf:
-          filters:
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
+          filters: *all_branches_and_tags
+          #   branches:
+          #     only:
+          #       - master
+          #       # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+          #       - /^v[0-9]+\.[0-9]+/
+          #   tags:
+          #     only:
+          #       - /.+/
       # Increase chart version for master, this will end up trigger deployment on dev
       - increase_chart_version_watcher_master:
           requires: [publish_watcher, publish_watcher_info]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1111,15 +1111,16 @@ workflows:
           filters: *master_and_version_branches_and_all_tags
 
       - publish_perf:
-          filters:
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
+          filters: *all_branches_and_tags
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
+          #       # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+          #       - /^v[0-9]+\.[0-9]+/
+          #   tags:
+          #     only:
+          #       - /.+/
       # Increase chart version for master, this will end up trigger deployment on dev
       - increase_chart_version_watcher_master:
           requires: [publish_watcher, publish_watcher_info]

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,9 @@ docker-watcher: docker-watcher-prod docker-watcher-build
 docker-watcher_info: docker-watcher_info-prod docker-watcher_info-build
 docker-child_chain: docker-child_chain-prod docker-child_chain-build
 
+docker-perf:
+	docker build -f ./priv/perf/Dockerfile -t $(IMAGE_NAME) .
+
 docker-build: docker-watcher docker-watcher_info docker-child_chain
 
 docker-push: docker

--- a/apps/omg_eth/test/support/dev_geth.ex
+++ b/apps/omg_eth/test/support/dev_geth.ex
@@ -103,7 +103,7 @@ defmodule OMG.Eth.DevGeth do
 
     waiting_task
     |> Task.async()
-    |> Task.await(30_000)
+    |> Task.await(90_000)
 
     pid
   end
@@ -112,7 +112,7 @@ defmodule OMG.Eth.DevGeth do
     if ready?(pid) do
       :ok
     else
-      Process.sleep(1_000)
+      Process.sleep(2_000)
       wait_for_rpc(pid)
     end
   end

--- a/priv/perf/Dockerfile
+++ b/priv/perf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add git curl bash maven jq \
         gnupg \
         alpine-sdk
 
-RUN git clone https://github.com/omgnetwork/elixir-omg
+COPY ./ ./elixir-omg
 
 WORKDIR ./elixir-omg
 

--- a/priv/perf/Dockerfile
+++ b/priv/perf/Dockerfile
@@ -1,0 +1,41 @@
+FROM elixir:1.10.4-alpine
+
+RUN apk add git curl bash maven jq \
+        autoconf \
+        automake \
+        gmp \
+        gmp-dev \
+        libtool \
+        gcc \
+        cmake \
+        gnupg \
+        alpine-sdk
+
+RUN git clone https://github.com/omgnetwork/elixir-omg
+
+WORKDIR ./elixir-omg
+
+RUN mkdir -p priv/openapitools \
+        && curl https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/bin/utils/openapi-generator-cli.sh > priv/openapitools/openapi-generator-cli \
+        && chmod u+x priv/openapitools/openapi-generator-cli
+
+RUN priv/openapitools/openapi-generator-cli generate \
+        -i https://raw.githubusercontent.com/omgnetwork/omg-childchain-v1/master/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml \
+        -g elixir \
+        -o priv/perf/apps/child_chain_api/
+
+RUN priv/openapitools/openapi-generator-cli generate \
+        -i apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml \
+        -g elixir \
+        -o priv/perf/apps/watcher_security_critical_api/
+
+RUN priv/openapitools/openapi-generator-cli generate \
+        -i apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml \
+        -g elixir \
+        -o priv/perf/apps/watcher_info_api/
+
+RUN mix local.hex --force && mix local.rebar --force
+
+WORKDIR ./priv/perf
+
+RUN mix deps.get && mix compile

--- a/priv/perf/Makefile
+++ b/priv/perf/Makefile
@@ -14,6 +14,9 @@ start-services:
 	cd priv/perf/ && \
 	docker-compose $(COMPOSE_FULL_SERVICES) up -d
 
+docker:
+	docker build -f ./Dockerfile -t $(IMAGE_NAME) .
+
 stop-services:
 	docker-compose $(COMPOSE_FULL_SERVICES) down
 

--- a/priv/perf/Makefile
+++ b/priv/perf/Makefile
@@ -14,9 +14,6 @@ start-services:
 	cd priv/perf/ && \
 	docker-compose $(COMPOSE_FULL_SERVICES) up -d
 
-docker:
-	docker build -f ./Dockerfile -t $(IMAGE_NAME) .
-
 stop-services:
 	docker-compose $(COMPOSE_FULL_SERVICES) down
 


### PR DESCRIPTION
This PR adds publishing of the perf project docker image to docker hub during circle ci builds so the perf project can be used as a standalone application outside of elixir-omg.