### PR TITLE
feat: add new metadata to Datadog traces

### DIFF
--- a/apps/omg_watcher_rpc/lib/application.ex
+++ b/apps/omg_watcher_rpc/lib/application.ex
@@ -29,7 +29,8 @@ defmodule OMG.WatcherRPC.Application do
     _ =
       SpandexPhoenix.Telemetry.install(
         endpoint_telemetry_prefix: [:watcher_rpc, :endpoint],
-        tracer: OMG.WatcherRPC.Tracer
+        tracer: OMG.WatcherRPC.Tracer,
+        customize_metadata: &OMG.WatcherRPC.Tracer.add_trace_metadata/1
       )
 
     children = [

--- a/apps/omg_watcher_rpc/lib/tracer.ex
+++ b/apps/omg_watcher_rpc/lib/tracer.ex
@@ -18,4 +18,69 @@ defmodule OMG.WatcherRPC.Tracer do
   """
 
   use Spandex.Tracer, otp_app: :omg_watcher_rpc
+
+  @doc """
+  Given conn and parsed response body, return a span with extra metadata.
+
+  The service medata (default ':web') is overridden to be the name of the OMG service.
+
+  Metadata added to the span is not arbitrary and is validated by Spandex against a schema:
+
+  service(:atom) Required: The default service name to use for spans declared without a service
+  env(:string): A name used to identify the environment name, e.g prod or development
+  services([{:keyword, :atom}, :keyword]): A mapping of service name to the default span types. - Default: []
+  completion_time(:integer)
+  error(:keyword)
+  http(:keyword)
+  id(:any)
+  name(:string)
+  parent_id(:any)
+  private(:keyword) - Default: []
+  resource([:atom, :string])
+  sql_query(:keyword)
+  start(:integer)
+  tags(:keyword) - Default: []
+  trace_id(:any)
+  type(:atom)
+  """
+  defp add_metadata_from_response_body(conn, json_resp_body) do
+    service = String.to_atom(json_resp_body["service_name"])
+    error = if !json_resp_body["success"], do: Keyword.new([{:error, true}])
+    error_type = if !!error and json_resp_body["data"], do: json_resp_body["data"]["code"]
+    error_msg = if !!error and json_resp_body["data"], do: json_resp_body["data"]["description"]
+
+    tags = [
+      {:version, json_resp_body["version"]}
+    ]
+
+    _ = if error_type, do: tags ++ {String.to_atom("error.type"), error_type}
+    _ = if error_msg, do: tags ++ {String.to_atom("error.msg"), error_msg}
+
+    trace_data =
+      conn
+      |> SpandexPhoenix.default_metadata()
+      |> Keyword.put(:service, service)
+      |> Keyword.put(:tags, tags)
+
+    if error,
+      do:
+        trace_data
+        |> Keyword.put(:error, error),
+      else: trace_data
+  end
+
+  @doc """
+  Adds metadata from the response body to the Spandex span.
+
+  The conn is inspected just before sending back the API response.
+
+  Handles failure to decode the response body gracefully.
+  """
+
+  def add_trace_metadata(conn) do
+    case Jason.decode(conn.resp_body) do
+      {:ok, json_resp_body} -> add_metadata_from_response_body(conn, json_resp_body)
+      {:error, _} -> SpandexPhoenix.default_metadata(conn)
+    end
+  end
 end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/tracer_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/tracer_test.exs
@@ -1,0 +1,98 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.WatcherRPC.TracerTest do
+  use ExUnit.Case, async: true
+  alias OMG.WatcherRPC.Tracer
+
+  test "api responses without errors are traced" do
+    resp_body = """
+    {
+      "data": [],
+      "service_name": "watcher",
+      "success": true,
+      "version": "1.0.4+33c3300"
+    }
+    """
+
+    conn =
+      Phoenix.ConnTest.build_conn(:get, "/alerts.get")
+      |> Plug.Conn.resp(200, resp_body)
+
+    actual_trace = Tracer.add_trace_metadata(conn)
+
+    expected_trace =
+      Keyword.new([
+        {:tags, [version: "1.0.4+33c3300"]},
+        {:service, :watcher},
+        {:http, [method: "GET", query_string: "", status_code: 200, url: "/alerts.get", user_agent: nil]},
+        {:resource, "GET /alerts.get"},
+        {:type, :web}
+      ])
+
+    assert expected_trace == actual_trace
+  end
+
+  test "if api responses with errors are traced" do
+    resp_body = """
+    {
+      "data": {
+      "code": "operation:not_found",
+      "description": "Operation cannot be found. Check request URL.",
+      "object": "error"
+      },
+      "service_name": "watcher_info",
+      "success": false,
+      "version": "1.0.4+33c3300"
+    }
+    """
+
+    conn =
+      Phoenix.ConnTest.build_conn(:post, "/")
+      |> Plug.Conn.resp(200, resp_body)
+
+    actual_trace = Tracer.add_trace_metadata(conn)
+
+    expected_trace =
+      Keyword.new([
+        {:error, [error: true]},
+        {:tags, [version: "1.0.4+33c3300"]},
+        {:service, :watcher_info},
+        {:http, [method: "POST", query_string: "", status_code: 200, url: "/", user_agent: nil]},
+        {:resource, "POST /"},
+        {:type, :web}
+      ])
+
+    assert expected_trace == actual_trace
+  end
+
+  test "conn with unparseable resp body is still traced" do
+    resp_body = "foo"
+
+    conn =
+      Phoenix.ConnTest.build_conn(:post, "/foo.get")
+      |> Plug.Conn.resp(200, resp_body)
+
+    actual_trace = Tracer.add_trace_metadata(conn)
+
+    expected_trace =
+      Keyword.new([
+        {:http, [method: "POST", query_string: "", status_code: 200, url: "/foo.get", user_agent: nil]},
+        {:resource, "POST /foo.get"},
+        {:type, :web}
+      ])
+
+    assert expected_trace == actual_trace
+  end
+end


### PR DESCRIPTION
## Overview

Because API responses are always 200, even if there's an error message in the body of the response, observability is impacted and it's hard to understand the health of services. This PR adds extra fields to the spans of tags passing through the Watcher and Watcher Info Phoenix based APIs, which flags responses with errors in the trace in Datadog.

While Datadog generates metrics from traces, unfortunately it isn't possible to group the traces by error_type in the metrics count (see https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors), so we will need to add more instrumentation, counting errors hit with custom metrics. This'll be a different PR.

## Changes

What you see in Datadog traces after this change:
* The service name (default 'web' for Phoenix applications) is the nameof the OMG application.
* Traces are tagged with application version number
* For API responses which error, the trace is flagged red as an error, the error code is marked on the trace and the error message is found in the tags.

![image](https://user-images.githubusercontent.com/9812774/98370634-8ae39380-2043-11eb-852f-9ea35177085c.png)

This is implemented by using `customize_metadata` on the SpandexPhoenix tracer: https://hexdocs.pm/spandex_phoenix/SpandexPhoenix.html, parsing the JSON response body with Jason (hopefully a relatively cheap operation), and adding the fields to the default metadata.

## Testing

```
DD_API_KEY=<some-api-key> docker-compose -f docker-compose-watcher.yml -f docker-compose.dev.yml up
```

Make API calls to the endpoints, and check the local-development environment APM in Datadog. Look for services "watcher" and "watcher_info", and check the traces in the DataDog GUI.

## P.S.

This is my first Elixir PR. Please let me know how my code can be more idiomatic!