### PR TITLE
bug: aggressive test fix

### DIFF
--- a/apps/omg_watcher_info/test/omg_watcher_info/pending_block_processor_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/pending_block_processor_test.exs
@@ -48,7 +48,7 @@ defmodule OMG.WatcherInfo.PendingBlockProcessorTest do
       %{blknum: blknum_2} = insert(:pending_block)
       %{blknum: blknum_3} = insert(:pending_block)
 
-      assert_receive {:trace, ^pid, :receive, :timeout}, @interval
+      assert_receive {:trace, ^pid, :receive, :timeout}, @interval + 50
       get_state(pid)
 
       assert [%{blknum: ^blknum_1}] = get_all_blocks()


### PR DESCRIPTION
Gold team closing #1428 too aggressive test
https://app.circleci.com/pipelines/github/omgnetwork/elixir-omg/8948/workflows/ebcef81a-c492-4f05-adda-ec4860291272/jobs/87658


```
1) test handle_info/2 processes the next pending block in queue (OMG.WatcherInfo.PendingBlockProcessorTest)
     apps/omg_watcher_info/test/omg_watcher_info/pending_block_processor_test.exs:41
     Found message matching {:trace, ^pid, :receive, :timeout} after 200ms.
     
     This means the message was delivered too close to the timeout value, you may want to either:
     
       1. Give an increased timeout to `assert_receive/2`
       2. Increase the default timeout to all `assert_receive` in your
          test_helper.exs by setting ExUnit.configure(assert_receive_timeout: ...)
     
     code: assert_receive {:trace, ^pid, :receive, :timeout}
     stacktrace:
       test/omg_watcher_info/pending_block_processor_test.exs:51: (test)
```