### PR TITLE
retry datadog errors

### DIFF
--- a/priv/perf/apps/load_test/lib/service/datadog/api.ex
+++ b/priv/perf/apps/load_test/lib/service/datadog/api.ex
@@ -86,11 +86,11 @@ defmodule LoadTest.Service.Datadog.API do
         {:ok, events}
 
       {:ok, %{body: body}} ->
-        Logger.error("failed to fetch events #{inspect(body)}")
+        Logger.warn("failed to fetch events #{inspect(body)}. retrying")
         fetch_events(start_time, end_time, environment, retries - 1)
 
       {:error, error} ->
-        Logger.error("failed to fetch events #{inspect(error)}")
+        Logger.warn("failed to fetch events #{inspect(error)}. retrying")
         fetch_events(start_time, end_time, environment, retries - 1)
     end
   end
@@ -143,14 +143,14 @@ defmodule LoadTest.Service.Datadog.API do
         :ok
 
       {:ok, %{body: body}} ->
-        Logger.error("failed to resolve monitors #{inspect(body)}")
+        Logger.warn("failed to resolve monitors #{inspect(body)}. retrying")
 
         Process.sleep(1_000)
 
         do_resolve_monitors(params, retries - 1)
 
       {:error, error} ->
-        Logger.error("failed to resolve monitors #{inspect(error)}")
+        Logger.warn("failed to resolve monitors #{inspect(error)}. retrying")
 
         Process.sleep(1_000)
 


### PR DESCRIPTION
in https://github.com/omgnetwork/elixir-omg/commit/dcc2d3d05383531ececef79020c266d112fb1438 datadog metrics were introduced.

Datadog api is timing out during ci runs sometimes

https://app.circleci.com/pipelines/github/omgnetwork/elixir-omg/8969/workflows/bdf890f7-2cd8-435e-81d7-8c4519e153d4/jobs/88002
