### PR TITLE
fix: set service name as a tag in metrics

### DIFF
--- a/apps/omg_status/lib/omg_status/metric/telemetry.ex
+++ b/apps/omg_status/lib/omg_status/metric/telemetry.ex
@@ -35,11 +35,12 @@ defmodule OMG.Status.Metric.Telemetry do
         TelemetryMetricsStatsd,
         metrics: metrics(),
         global_tags: [
+          service: service,
           version: version
         ],
         host: dd_host,
         port: dd_port,
-        prefix: "omg.#{service}",
+        prefix: "elixir",
         formatter: :datadog
       }
     ]
@@ -52,29 +53,29 @@ defmodule OMG.Status.Metric.Telemetry do
       # Phoenix Metrics
       summary(
         "phoenix.endpoint.stop.duration",
-        tags: [:version],
+        tags: [:service, :version],
         unit: {:native, :millisecond}
       ),
       summary(
         "phoenix.router_dispatch.stop.duration",
-        tags: [:version, :route],
+        tags: [:service, :version, :route],
         unit: {:native, :millisecond}
       ),
       summary(
         "phoenix.router_dispatch.exception.duration",
-        tags: [:version, :kind],
+        tags: [:service, :version, :kind],
         unit: {:native, :millisecond}
       ),
       summary(
         "phoenix.error_rendered.duration",
-        tags: [:version, :kind],
+        tags: [:service, :version, :kind],
         unit: {:native, :millisecond}
       ),
 
       # Custom web metrics
       counter(
         "web.fallback.error",
-        tags: [:version, :route, :error_code]
+        tags: [:service, :version, :route, :error_code]
       )
     ]
   end


### PR DESCRIPTION
## Overview

Currently the service name is part of the prefix for metrics, but it
would be far better if it were a tag, so that services could be compared
side by side in Datadog.

Rename the prefix to 'elixir'.

## Changes

- Move the service name from being part of the prefix in the name of a metric to a tag on the metric.

## Testing

```
docker-compose -f docker-compose-watcher.yml -f docker-compose.dev.yml up
﻿make docker-update-watcher
make docker-update-watcher_info
```

Check that metrics appear as omg.phoenix. ... with the service as a tag in Datadog. And this has been tested.