### PR TITLE
chore: add sem release automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1026,153 +1026,166 @@ workflows:
       - test_barebone_release
   build-test-deploy:
     jobs:
-      # - build:
-      #     filters: &all_branches_and_tags
-      #       branches:
-      #         only: /.+/
-      #       tags:
-      #         only: /.+/
-      # - test_barebone_release:
-      #     filters: *all_branches_and_tags
-      # - notify_services:
-      #     requires:
-      #       - increase_chart_version_watcher_master
-      #       - increase_chart_version_watcher_info_master
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - coveralls_report:
-      #     requires:
-      #       - watcher_coveralls_and_integration_tests
-      #       - watcher_info_coveralls_and_integration_tests
-      #       - common_coveralls_and_integration_tests
-      #       - test
-      # - watcher_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - watcher_info_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - common_coveralls_and_integration_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - test_docker_compose_release:
-      #     filters: *all_branches_and_tags
-      # - test_docker_compose_performance:
-      #     filters: *all_branches_and_tags
-      # - test_docker_compose_reorg:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           - master-v2
-      # - audit_deps:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - lint:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - lint_version:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - sobelow:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - dialyzer:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - test:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - property_tests:
-      #     requires: [build]
-      #     filters: *all_branches_and_tags
-      # - watcher_mix_based_childchain:
-      #     filters: *all_branches_and_tags
-      # - publish_watcher:
-      #     requires:
-      #       [
-      #         test_barebone_release,
-      #         test_docker_compose_release,
-      #         watcher_coveralls_and_integration_tests,
-      #         watcher_info_coveralls_and_integration_tests,
-      #         common_coveralls_and_integration_tests,
-      #         test,
-      #         property_tests,
-      #         dialyzer,
-      #         lint,
-      #         lint_version,
-      #         audit_deps
-      #       ]
-      #     filters: &master_and_version_branches_and_all_tags
-      #       branches:
-      #         only:
-      #           - master
-      #           # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-      #           - /^v[0-9]+\.[0-9]+/
-      #       tags:
-      #         only:
-      #           - /.+/
-      # - publish_watcher_info:
-      #     requires:
-      #       [
-      #         test_barebone_release,
-      #         test_docker_compose_release,
-      #         watcher_coveralls_and_integration_tests,
-      #         watcher_info_coveralls_and_integration_tests,
-      #         common_coveralls_and_integration_tests,
-      #         test,
-      #         property_tests,
-      #         dialyzer,
-      #         lint,
-      #         lint_version,
-      #         audit_deps
-      #       ]
-      #     filters: *master_and_version_branches_and_all_tags
+      - build:
+          filters: &all_branches_and_tags
+            branches:
+              only: /.+/
+            tags:
+              only: /.+/
+      - test_barebone_release:
+          filters: *all_branches_and_tags
+      - notify_services:
+          requires:
+            - increase_chart_version_watcher_master
+            - increase_chart_version_watcher_info_master
+          filters:
+            branches:
+              only:
+                - master
+      - coveralls_report:
+          requires:
+            - watcher_coveralls_and_integration_tests
+            - watcher_info_coveralls_and_integration_tests
+            - common_coveralls_and_integration_tests
+            - test
+      - watcher_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - watcher_info_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - common_coveralls_and_integration_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - test_docker_compose_release:
+          filters: *all_branches_and_tags
+      - test_docker_compose_performance:
+          filters: *all_branches_and_tags
+      - test_docker_compose_reorg:
+          filters:
+            branches:
+              only:
+                - master
+                - master-v2
+      - audit_deps:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - lint:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - lint_version:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - sobelow:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - dialyzer:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - test:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - property_tests:
+          requires: [build]
+          filters: *all_branches_and_tags
+      - watcher_mix_based_childchain:
+          filters: *all_branches_and_tags
+      - publish_watcher:
+          requires:
+            [
+              test_barebone_release,
+              test_docker_compose_release,
+              watcher_coveralls_and_integration_tests,
+              watcher_info_coveralls_and_integration_tests,
+              common_coveralls_and_integration_tests,
+              test,
+              property_tests,
+              dialyzer,
+              lint,
+              lint_version,
+              audit_deps
+            ]
+          filters: &master_and_version_branches_and_all_tags
+            branches:
+              only:
+                - master
+                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+                - /^v[0-9]+\.[0-9]+/
+            tags:
+              only:
+                - /.+/
+      - publish_watcher_info:
+          requires:
+            [
+              test_barebone_release,
+              test_docker_compose_release,
+              watcher_coveralls_and_integration_tests,
+              watcher_info_coveralls_and_integration_tests,
+              common_coveralls_and_integration_tests,
+              test,
+              property_tests,
+              dialyzer,
+              lint,
+              lint_version,
+              audit_deps
+            ]
+          filters: *master_and_version_branches_and_all_tags
 
-      # - publish_perf:
-      #     requires: [test_docker_compose_performance]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-      #           - /^v[0-9]+\.[0-9]+/
-      #       tags:
-      #         only:
-      #           - /.+/
-      # # Increase chart version for master, this will end up trigger deployment on dev
-      # - increase_chart_version_watcher_master:
-      #     requires: [publish_watcher, publish_watcher_info]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - increase_chart_version_watcher_info_master:
-      #     requires: [publish_watcher, publish_watcher_info]
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # # Increase chart version for new release
-      # - increase_chart_version_watcher_release:
-      #     requires: [publish_watcher, publish_watcher_info]
-      #     filters: &only_release_tag
-      #       branches:
-      #         ignore: /.*/
-      #       tags:
-      #         only:
-      #           # eg. v1.0.3-pre.0, v1.0.3, ...
-      #           - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
-      # - increase_chart_version_watcher_info_release:
-      #     requires: [publish_watcher, publish_watcher_info]
-      #     filters: *only_release_tag
+      - publish_perf:
+          requires: [test_docker_compose_performance]
+          filters:
+            branches:
+              only:
+                - master
+                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+                - /^v[0-9]+\.[0-9]+/
+            tags:
+              only:
+                - /.+/
+      # Increase chart version for master, this will end up trigger deployment on dev
+      - increase_chart_version_watcher_master:
+          requires: [publish_watcher, publish_watcher_info]
+          filters:
+            branches:
+              only:
+                - master
+      - increase_chart_version_watcher_info_master:
+          requires: [publish_watcher, publish_watcher_info]
+          filters:
+            branches:
+              only:
+                - master
+      # Increase chart version for new release
+      - increase_chart_version_watcher_release:
+          requires: [publish_watcher, publish_watcher_info]
+          filters: &only_release_tag
+            branches:
+              ignore: /.*/
+            tags:
+              only:
+                # eg. v1.0.3-pre.0, v1.0.3, ...
+                - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - increase_chart_version_watcher_info_release:
+          requires: [publish_watcher, publish_watcher_info]
+          filters: *only_release_tag
       - release:
+          requires: [
+            test_barebone_release,
+            test_docker_compose_release,
+            watcher_coveralls_and_integration_tests,
+            watcher_info_coveralls_and_integration_tests,
+            common_coveralls_and_integration_tests,
+            test,
+            property_tests,
+            dialyzer,
+            lint,
+            lint_version,
+            audit_deps
+          ]
           context:
           - shared-semantic-release
-          # filters:
-          #   branches:
-          #     only: /^master$/
-          #   tags:
-          #     ignore: /.*/
+          filters:
+            branches:
+              only: /^master$/
+            tags:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -952,6 +952,13 @@ jobs:
       - checkout
       - run: APP_VERSION="${CIRCLE_TAG#*v}" sh .circleci/ci_increase_chart_version.sh
 
+  release:
+    docker:
+      - image: node:15.2.1
+    steps:
+      - checkout
+      - run: npx -y semantic-release@17.2.3
+
   coveralls_report:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
@@ -1019,145 +1026,153 @@ workflows:
       - test_barebone_release
   build-test-deploy:
     jobs:
-      - build:
-          filters: &all_branches_and_tags
-            branches:
-              only: /.+/
-            tags:
-              only: /.+/
-      - test_barebone_release:
-          filters: *all_branches_and_tags
-      - notify_services:
-          requires:
-            - increase_chart_version_watcher_master
-            - increase_chart_version_watcher_info_master
-          filters:
-            branches:
-              only:
-                - master
-      - coveralls_report:
-          requires:
-            - watcher_coveralls_and_integration_tests
-            - watcher_info_coveralls_and_integration_tests
-            - common_coveralls_and_integration_tests
-            - test
-      - watcher_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - watcher_info_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - common_coveralls_and_integration_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - test_docker_compose_release:
-          filters: *all_branches_and_tags
-      - test_docker_compose_performance:
-          filters: *all_branches_and_tags
-      - test_docker_compose_reorg:
-          filters:
-            branches:
-              only:
-                - master
-                - master-v2
-      - audit_deps:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - lint:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - lint_version:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - sobelow:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - dialyzer:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - test:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - property_tests:
-          requires: [build]
-          filters: *all_branches_and_tags
-      - watcher_mix_based_childchain:
-          filters: *all_branches_and_tags
-      - publish_watcher:
-          requires:
-            [
-              test_barebone_release,
-              test_docker_compose_release,
-              watcher_coveralls_and_integration_tests,
-              watcher_info_coveralls_and_integration_tests,
-              common_coveralls_and_integration_tests,
-              test,
-              property_tests,
-              dialyzer,
-              lint,
-              lint_version,
-              audit_deps
-            ]
-          filters: &master_and_version_branches_and_all_tags
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
-      - publish_watcher_info:
-          requires:
-            [
-              test_barebone_release,
-              test_docker_compose_release,
-              watcher_coveralls_and_integration_tests,
-              watcher_info_coveralls_and_integration_tests,
-              common_coveralls_and_integration_tests,
-              test,
-              property_tests,
-              dialyzer,
-              lint,
-              lint_version,
-              audit_deps
-            ]
-          filters: *master_and_version_branches_and_all_tags
+      # - build:
+      #     filters: &all_branches_and_tags
+      #       branches:
+      #         only: /.+/
+      #       tags:
+      #         only: /.+/
+      # - test_barebone_release:
+      #     filters: *all_branches_and_tags
+      # - notify_services:
+      #     requires:
+      #       - increase_chart_version_watcher_master
+      #       - increase_chart_version_watcher_info_master
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - coveralls_report:
+      #     requires:
+      #       - watcher_coveralls_and_integration_tests
+      #       - watcher_info_coveralls_and_integration_tests
+      #       - common_coveralls_and_integration_tests
+      #       - test
+      # - watcher_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - watcher_info_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - common_coveralls_and_integration_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - test_docker_compose_release:
+      #     filters: *all_branches_and_tags
+      # - test_docker_compose_performance:
+      #     filters: *all_branches_and_tags
+      # - test_docker_compose_reorg:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           - master-v2
+      # - audit_deps:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - lint:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - lint_version:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - sobelow:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - dialyzer:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - test:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - property_tests:
+      #     requires: [build]
+      #     filters: *all_branches_and_tags
+      # - watcher_mix_based_childchain:
+      #     filters: *all_branches_and_tags
+      # - publish_watcher:
+      #     requires:
+      #       [
+      #         test_barebone_release,
+      #         test_docker_compose_release,
+      #         watcher_coveralls_and_integration_tests,
+      #         watcher_info_coveralls_and_integration_tests,
+      #         common_coveralls_and_integration_tests,
+      #         test,
+      #         property_tests,
+      #         dialyzer,
+      #         lint,
+      #         lint_version,
+      #         audit_deps
+      #       ]
+      #     filters: &master_and_version_branches_and_all_tags
+      #       branches:
+      #         only:
+      #           - master
+      #           # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+      #           - /^v[0-9]+\.[0-9]+/
+      #       tags:
+      #         only:
+      #           - /.+/
+      # - publish_watcher_info:
+      #     requires:
+      #       [
+      #         test_barebone_release,
+      #         test_docker_compose_release,
+      #         watcher_coveralls_and_integration_tests,
+      #         watcher_info_coveralls_and_integration_tests,
+      #         common_coveralls_and_integration_tests,
+      #         test,
+      #         property_tests,
+      #         dialyzer,
+      #         lint,
+      #         lint_version,
+      #         audit_deps
+      #       ]
+      #     filters: *master_and_version_branches_and_all_tags
 
-      - publish_perf:
-          requires: [test_docker_compose_performance]
-          filters:
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
-      # Increase chart version for master, this will end up trigger deployment on dev
-      - increase_chart_version_watcher_master:
-          requires: [publish_watcher, publish_watcher_info]
-          filters:
-            branches:
-              only:
-                - master
-      - increase_chart_version_watcher_info_master:
-          requires: [publish_watcher, publish_watcher_info]
-          filters:
-            branches:
-              only:
-                - master
-      # Increase chart version for new release
-      - increase_chart_version_watcher_release:
-          requires: [publish_watcher, publish_watcher_info]
-          filters: &only_release_tag
-            branches:
-              ignore: /.*/
-            tags:
-              only:
-                # eg. v1.0.3-pre.0, v1.0.3, ...
-                - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
-      - increase_chart_version_watcher_info_release:
-          requires: [publish_watcher, publish_watcher_info]
-          filters: *only_release_tag
+      # - publish_perf:
+      #     requires: [test_docker_compose_performance]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
+      #           - /^v[0-9]+\.[0-9]+/
+      #       tags:
+      #         only:
+      #           - /.+/
+      # # Increase chart version for master, this will end up trigger deployment on dev
+      # - increase_chart_version_watcher_master:
+      #     requires: [publish_watcher, publish_watcher_info]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - increase_chart_version_watcher_info_master:
+      #     requires: [publish_watcher, publish_watcher_info]
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # # Increase chart version for new release
+      # - increase_chart_version_watcher_release:
+      #     requires: [publish_watcher, publish_watcher_info]
+      #     filters: &only_release_tag
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only:
+      #           # eg. v1.0.3-pre.0, v1.0.3, ...
+      #           - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      # - increase_chart_version_watcher_info_release:
+      #     requires: [publish_watcher, publish_watcher_info]
+      #     filters: *only_release_tag
+      - release:
+          context:
+          - shared-semantic-release
+          # filters:
+          #   branches:
+          #     only: /^master$/
+          #   tags:
+          #     ignore: /.*/

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,17 +1,17 @@
 plugins:
-- '@semantic-release/commit-analyzer':
-  preset: 'angular'
-  releaseRules:
-    - type: 'refactor'
-      release: 'patch'
-    - type: 'style'
-      release: 'patch'
-    - type: 'feat'
-      release: 'patch'
-    - type: 'chore'
-      release: 'patch'
-    - breaking: true
-      release: 'minor'
+- - '@semantic-release/commit-analyzer'
+  - preset: 'angular'
+    releaseRules:
+      - type: 'refactor'
+        release: 'patch'
+      - type: 'style'
+        release: 'patch'
+      - type: 'feat'
+        release: 'patch'
+      - type: 'chore'
+        release: 'patch'
+      - breaking: true
+        release: 'minor'
 - '@semantic-release/release-notes-generator'
 - '@semantic-release/github'
 tagFormat: 'v${version}'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -15,3 +15,4 @@ plugins:
 - '@semantic-release/release-notes-generator'
 - '@semantic-release/github'
 tagFormat: 'v${version}'
+dryRun: true

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,5 @@
+plugins:
+- '@semantic-release/commit-analyzer'
+- '@semantic-release/release-notes-generator'
+- '@semantic-release/github'
+tagFormat: 'v${version}'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,5 +1,17 @@
 plugins:
-- '@semantic-release/commit-analyzer'
+- '@semantic-release/commit-analyzer':
+  preset: 'angular'
+  releaseRules:
+    - type: 'refactor'
+      release: 'patch'
+    - type: 'style'
+      release: 'patch'
+    - type: 'feat'
+      release: 'patch'
+    - type: 'chore'
+      release: 'patch'
+    - breaking: true
+      release: 'minor'
 - '@semantic-release/release-notes-generator'
 - '@semantic-release/github'
 tagFormat: 'v${version}'


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Add Semitic release tool to elixir-omg. This will auto create release on commit to master.
See this for more detail: https://omisego.atlassian.net/wiki/spaces/ENG/pages/937918471/Releases+of+a+git+repo

## Changes

- add the tool to circle ci
- currently in dry-run mode. I am slightly concerned on initial tag creation as we got old tags existing.

## Testing

messed around on my playground repo

- dry-run result: https://app.circleci.com/pipelines/github/omgnetwork/elixir-omg-boolafish-playground/142/workflows/da8a2fb3-071b-4431-bc0b-268c22c5b237/jobs/470
- non dry-run tagged: https://github.com/omgnetwork/elixir-omg-boolafish-playground/releases/tag/v1.0.1

