### PR TITLE
fix: make sem release ignore PR check

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -16,3 +16,9 @@ plugins:
 - '@semantic-release/github'
 tagFormat: 'v${version}'
 dryRun: true
+# observing that job would not be running as it was considered as from PR branch
+# looks that unfortunately that is how it is designed:
+# https://github.com/semantic-release/semantic-release/issues/1166#issuecomment-500094323
+# this workaround is from:
+# https://github.com/semantic-release/semantic-release/issues/1074#issuecomment-696922883
+ci: false


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

> This run was triggered by a pull request and therefore a new version won't be published.

Observed this from this: [job](https://app.circleci.com/pipelines/github/omgnetwork/elixir-omg/9170/workflows/c3cfc660-7833-4f23-a247-204fd427e2e3/jobs/90895)

## Changes

set ci check to false, following this: https://github.com/semantic-release/semantic-release/issues/1074#issuecomment-696922883

## Testing

N/A, waiting the merge to run the dry-run
